### PR TITLE
fix(header): align subscribe icon with other nav actions

### DIFF
--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -18,7 +18,7 @@ const webcalUrl = computed(() => `webcal://${location.host}${calendarUrl}`)
     </div>
 
     <nav flex="~ items-center gap-4">
-      <div relative>
+      <div inline-flex relative>
         <button class="icon-btn" title="订阅日历" @click="subscribeOpen = !subscribeOpen">
           <div i-carbon-calendar-add />
         </button>


### PR DESCRIPTION
## Summary
- Header subscribe button wrapper div changed from block to inline-flex so line-height no longer stretches the box and misaligns the icon
- Vertically aligns with the other three icon-btn actions

## Test plan
- [ ] Open homepage and confirm the four top-right icons share one horizontal baseline
- [ ] Click subscribe and confirm the dropdown still positions correctly
- [ ] Toggle dark mode and confirm icon alignment still holds