### PR TITLE
fix: reset scroll position on page navigation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { ViteSSG } from 'vite-ssg'
 import { routes } from 'vue-router/auto-routes'
 import App from './App.vue'
+import { scrollBehavior } from './router'
 
 import './styles/main.css'
 import 'uno.css'
@@ -14,4 +15,5 @@ import './styles/event-theme.css'
 export const createApp = ViteSSG(App, {
   routes,
   base: import.meta.env.BASE_URL,
+  scrollBehavior,
 })

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,0 +1,7 @@
+import type { RouterScrollBehavior } from 'vue-router'
+
+/**
+ * Keeps browser history navigation natural while ensuring every new page starts at the top.
+ */
+export const scrollBehavior: RouterScrollBehavior = (_to, _from, savedPosition) =>
+  savedPosition ?? { top: 0 }

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { scrollBehavior } from '../src/router'
+
+const route = null as never
+
+describe('scrollBehavior', () => {
+  it('starts regular navigations at the top of the page', () => {
+    expect(scrollBehavior(route, route, null)).toEqual({ top: 0 })
+  })
+
+  it('restores the saved position for browser history navigation', () => {
+    const savedPosition = { left: 0, top: 640 }
+
+    expect(scrollBehavior(route, route, savedPosition)).toBe(savedPosition)
+  })
+})


### PR DESCRIPTION
## What changed

- add a global Vue Router scroll behavior
- reset regular page navigations to the top
- preserve saved scroll positions for browser back/forward navigation
- cover both behaviors with regression tests

## Root cause

The router had no `scrollBehavior` configured. SPA navigation therefore reused the current document scroll offset, so opening an event detail page from a scrolled list could leave the detail page near the bottom. Browser history restoration could make the same issue visible on direct visits as well.

## Impact

New pages now consistently open at the top, while returning to the previous page still restores the user's prior position.

## Validation

- `pnpm run lint --fix`
- `pnpm run typecheck`
- `pnpm test --run` — 51 tests passed
- `pnpm build`
- browser verification: opening a detail page from a list scrolled to 2898px resulted in `scrollY = 0`; navigating back restored the list to its previous bottom region