### PR TITLE
fix(og): load theme icons without TypeScript stripping

### DIFF
--- a/scripts/generate-og.mjs
+++ b/scripts/generate-og.mjs
@@ -66,11 +66,10 @@ function resolveIcon(iconClass, color) {
   return { src: `data:image/svg+xml,${encodeURIComponent(svg)}`, width, height }
 }
 
-/** Best-effort event theme (brand color + up to 3 watermark icons) from tag-icons.ts. */
+/** Best-effort event theme (brand color + up to 3 watermark icons) from the shared plain-JavaScript data module. */
 async function loadEventTheme() {
   try {
-    // Node >= 23.6 strips types natively; older Node throws and we fall back.
-    const { tagIcons } = await import('../src/data/tag-icons.ts')
+    const { tagIcons } = await import('../src/data/tag-icons.mjs')
     return (tags) => {
       // Mirror src/utils/eventTheme.ts resolveEventTheme: tier !== 3, dedupe by
       // def identity, stable sort by tier ascending, take up to 3, primary = first.
@@ -86,10 +85,8 @@ async function loadEventTheme() {
     }
   }
   catch (err) {
-    // A silent fallback here once shipped icon-less OG images from a CI whose
-    // Node predated type stripping (see .node-version) — stay loud about it.
-    console.warn(`[gen:og] WARNING: failed to import src/data/tag-icons.ts (${err.message}).`)
-    console.warn('[gen:og] OG images will have NO theme icons and use the fallback color. Check the Node version (needs >= 22.18 / 23.6 for native TS import; pinned via .node-version).')
+    console.warn(`[gen:og] WARNING: failed to import src/data/tag-icons.mjs (${err.message}).`)
+    console.warn('[gen:og] OG images will have NO theme icons and use the fallback color.')
     return () => ({ color: '#14b8a6', icons: [] })
   }
 }

--- a/src/data/tag-icons.mjs
+++ b/src/data/tag-icons.mjs
@@ -1,0 +1,75 @@
+// @unocss-include
+// The directive above makes UnoCSS extract the `i-*` icon classes from this
+// plain .ts file (it is outside the default extraction pipeline).
+
+/** Shared defs so grouped tags (e.g. the AI family) dedupe to one card icon. */
+const ai = /** @type {const} */ ({ icon: 'i-carbon-machine-learning-model', color: '#8b5cf6', tier: 2 })
+const opensource = /** @type {const} */ ({ icon: 'i-simple-icons-opensourceinitiative', color: '#3da639', tier: 2 })
+const printing3d = /** @type {const} */ ({ icon: 'i-mdi-printer-3d', color: '#f97316', tier: 2 })
+const cloud = /** @type {const} */ ({ icon: 'i-carbon-cloud', color: '#0ea5e9', tier: 2 })
+const robotics = /** @type {const} */ ({ icon: 'i-mdi-robot', color: '#64748b', colorDark: '#94a3b8', tier: 2 })
+const frontend = /** @type {const} */ ({ icon: 'i-carbon-application-web', color: '#0891b2', tier: 2 })
+const startup = /** @type {const} */ ({ icon: 'i-mdi-rocket-launch', color: '#f43f5e', tier: 2 })
+const academia = /** @type {const} */ ({ icon: 'i-mdi-school', color: '#92400e', colorDark: '#d97706', tier: 2 })
+const python = /** @type {const} */ ({ icon: 'i-simple-icons-python', color: '#3776ab', tier: 1 })
+const google = /** @type {const} */ ({ icon: 'i-simple-icons-google', color: '#4285f4', tier: 1 })
+
+export const tagIcons = /** @type {const} */ ({
+  // --- Tier 1: brand / tech logos (official brand colors) ---
+  'vue': { icon: 'i-simple-icons-vuedotjs', color: '#42b883', tier: 1 },
+  'vite': { icon: 'i-simple-icons-vite', color: '#646cff', tier: 1 },
+  'javascript': { icon: 'i-simple-icons-javascript', color: '#b7a500', colorDark: '#f7df1e', tier: 1 },
+  'typescript': { icon: 'i-simple-icons-typescript', color: '#3178c6', tier: 1 },
+  'python': python,
+  'pycon': python,
+  'pytorch': { icon: 'i-simple-icons-pytorch', color: '#ee4c2c', tier: 1 },
+  'linux': { icon: 'i-simple-icons-linux', color: '#555555', colorDark: '#e0e0e0', tier: 1 },
+  'ubuntu': { icon: 'i-simple-icons-ubuntu', color: '#e95420', tier: 1 },
+  'kubernetes': { icon: 'i-simple-icons-kubernetes', color: '#326ce5', tier: 1 },
+  'cncf': { icon: 'i-simple-icons-cncf', color: '#446ca9', colorDark: '#9cb4d8', tier: 1 },
+  'aws': { icon: 'i-simple-icons-amazonwebservices', color: '#c77c02', colorDark: '#ff9900', tier: 1 },
+  'android': { icon: 'i-simple-icons-android', color: '#2aa15f', colorDark: '#3ddc84', tier: 1 },
+  'kotlin': { icon: 'i-simple-icons-kotlin', color: '#7f52ff', tier: 1 },
+  'apache': { icon: 'i-simple-icons-apache', color: '#d22128', tier: 1 },
+  'zabbix': { icon: 'i-carbon-cloud-monitoring', color: '#d40000', colorDark: '#ff5555', tier: 1 },
+  'openinfra': { icon: 'i-simple-icons-openstack', color: '#ed1944', tier: 1 },
+  'gdg': google,
+  'devfest': google,
+  'moonbit': { icon: 'i-carbon-moon', color: '#b92381', tier: 1 },
+
+  // --- Tier 2: domain concepts ---
+  'ai': ai,
+  'artificial-intelligence': ai,
+  'llm': ai,
+  'agentic-ai': ai,
+  'opensource': opensource,
+  'foss': opensource,
+  '3dprinting': printing3d,
+  'additive-manufacturing': printing3d,
+  'cloud': cloud,
+  'cloud-native': cloud,
+  'robotics': robotics,
+  'embodied-ai': robotics,
+  'hardware': { icon: 'i-carbon-chip', color: '#6366f1', tier: 2 },
+  'frontend': frontend,
+  'web': frontend,
+  'mobile': { icon: 'i-carbon-mobile', color: '#16a34a', tier: 2 },
+  'hackathon': { icon: 'i-mdi-lightning-bolt', color: '#d97706', colorDark: '#f59e0b', tier: 2 },
+  'startup': startup,
+  'demoday': startup,
+  'indiehacker': startup,
+  'academic': academia,
+  'computer-science': academia,
+  'student': academia,
+  'youth': academia,
+  'monitoring': { icon: 'i-carbon-dashboard', color: '#475569', colorDark: '#94a3b8', tier: 2 },
+  'compiler': { icon: 'i-carbon-code', color: '#374151', colorDark: '#9ca3af', tier: 2 },
+
+  // --- Tier 3: chip-only (neutral gray; never shown at card level) ---
+  'conference': { icon: 'i-carbon-presentation-file', color: '#64748b', tier: 3 },
+  'meetup': { icon: 'i-carbon-group', color: '#64748b', tier: 3 },
+  'community': { icon: 'i-carbon-events', color: '#64748b', tier: 3 },
+  'expo': { icon: 'i-carbon-building', color: '#64748b', tier: 3 },
+  'enterprise': { icon: 'i-carbon-enterprise', color: '#64748b', tier: 3 },
+  'maker': { icon: 'i-carbon-tools', color: '#64748b', tier: 3 },
+})

--- a/src/data/tag-icons.ts
+++ b/src/data/tag-icons.ts
@@ -1,6 +1,4 @@
-// @unocss-include
-// The directive above makes UnoCSS extract the `i-*` icon classes from this
-// plain .ts file (it is outside the default extraction pipeline).
+import { tagIcons as sharedTagIcons } from './tag-icons.mjs'
 
 export interface TagIconDef {
   /** UnoCSS icon class, any Iconify collection, e.g. 'i-simple-icons-vuedotjs'. */
@@ -17,74 +15,4 @@ export interface TagIconDef {
   tier: 1 | 2 | 3
 }
 
-/** Shared defs so grouped tags (e.g. the AI family) dedupe to one card icon. */
-const ai: TagIconDef = { icon: 'i-carbon-machine-learning-model', color: '#8b5cf6', tier: 2 }
-const opensource: TagIconDef = { icon: 'i-simple-icons-opensourceinitiative', color: '#3da639', tier: 2 }
-const printing3d: TagIconDef = { icon: 'i-mdi-printer-3d', color: '#f97316', tier: 2 }
-const cloud: TagIconDef = { icon: 'i-carbon-cloud', color: '#0ea5e9', tier: 2 }
-const robotics: TagIconDef = { icon: 'i-mdi-robot', color: '#64748b', colorDark: '#94a3b8', tier: 2 }
-const frontend: TagIconDef = { icon: 'i-carbon-application-web', color: '#0891b2', tier: 2 }
-const startup: TagIconDef = { icon: 'i-mdi-rocket-launch', color: '#f43f5e', tier: 2 }
-const academia: TagIconDef = { icon: 'i-mdi-school', color: '#92400e', colorDark: '#d97706', tier: 2 }
-const python: TagIconDef = { icon: 'i-simple-icons-python', color: '#3776ab', tier: 1 }
-const google: TagIconDef = { icon: 'i-simple-icons-google', color: '#4285f4', tier: 1 }
-
-export const tagIcons: Record<string, TagIconDef> = {
-  // --- Tier 1: brand / tech logos (official brand colors) ---
-  'vue': { icon: 'i-simple-icons-vuedotjs', color: '#42b883', tier: 1 },
-  'vite': { icon: 'i-simple-icons-vite', color: '#646cff', tier: 1 },
-  'javascript': { icon: 'i-simple-icons-javascript', color: '#b7a500', colorDark: '#f7df1e', tier: 1 },
-  'typescript': { icon: 'i-simple-icons-typescript', color: '#3178c6', tier: 1 },
-  'python': python,
-  'pycon': python,
-  'pytorch': { icon: 'i-simple-icons-pytorch', color: '#ee4c2c', tier: 1 },
-  'linux': { icon: 'i-simple-icons-linux', color: '#555555', colorDark: '#e0e0e0', tier: 1 },
-  'ubuntu': { icon: 'i-simple-icons-ubuntu', color: '#e95420', tier: 1 },
-  'kubernetes': { icon: 'i-simple-icons-kubernetes', color: '#326ce5', tier: 1 },
-  'cncf': { icon: 'i-simple-icons-cncf', color: '#446ca9', colorDark: '#9cb4d8', tier: 1 },
-  'aws': { icon: 'i-simple-icons-amazonwebservices', color: '#c77c02', colorDark: '#ff9900', tier: 1 },
-  'android': { icon: 'i-simple-icons-android', color: '#2aa15f', colorDark: '#3ddc84', tier: 1 },
-  'kotlin': { icon: 'i-simple-icons-kotlin', color: '#7f52ff', tier: 1 },
-  'apache': { icon: 'i-simple-icons-apache', color: '#d22128', tier: 1 },
-  'zabbix': { icon: 'i-carbon-cloud-monitoring', color: '#d40000', colorDark: '#ff5555', tier: 1 },
-  'openinfra': { icon: 'i-simple-icons-openstack', color: '#ed1944', tier: 1 },
-  'gdg': google,
-  'devfest': google,
-  'moonbit': { icon: 'i-carbon-moon', color: '#b92381', tier: 1 },
-
-  // --- Tier 2: domain concepts ---
-  'ai': ai,
-  'artificial-intelligence': ai,
-  'llm': ai,
-  'agentic-ai': ai,
-  'opensource': opensource,
-  'foss': opensource,
-  '3dprinting': printing3d,
-  'additive-manufacturing': printing3d,
-  'cloud': cloud,
-  'cloud-native': cloud,
-  'robotics': robotics,
-  'embodied-ai': robotics,
-  'hardware': { icon: 'i-carbon-chip', color: '#6366f1', tier: 2 },
-  'frontend': frontend,
-  'web': frontend,
-  'mobile': { icon: 'i-carbon-mobile', color: '#16a34a', tier: 2 },
-  'hackathon': { icon: 'i-mdi-lightning-bolt', color: '#d97706', colorDark: '#f59e0b', tier: 2 },
-  'startup': startup,
-  'demoday': startup,
-  'indiehacker': startup,
-  'academic': academia,
-  'computer-science': academia,
-  'student': academia,
-  'youth': academia,
-  'monitoring': { icon: 'i-carbon-dashboard', color: '#475569', colorDark: '#94a3b8', tier: 2 },
-  'compiler': { icon: 'i-carbon-code', color: '#374151', colorDark: '#9ca3af', tier: 2 },
-
-  // --- Tier 3: chip-only (neutral gray; never shown at card level) ---
-  'conference': { icon: 'i-carbon-presentation-file', color: '#64748b', tier: 3 },
-  'meetup': { icon: 'i-carbon-group', color: '#64748b', tier: 3 },
-  'community': { icon: 'i-carbon-events', color: '#64748b', tier: 3 },
-  'expo': { icon: 'i-carbon-building', color: '#64748b', tier: 3 },
-  'enterprise': { icon: 'i-carbon-enterprise', color: '#64748b', tier: 3 },
-  'maker': { icon: 'i-carbon-tools', color: '#64748b', tier: 3 },
-}
+export const tagIcons: Record<string, TagIconDef> = sharedTagIcons

--- a/test/og-theme-data.test.ts
+++ b/test/og-theme-data.test.ts
@@ -1,0 +1,22 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('og theme data', () => {
+  it('is available from a plain JavaScript module that Node can load without TypeScript stripping', async () => {
+    const { tagIcons } = await import('../src/data/tag-icons.mjs')
+
+    expect(tagIcons.vue).toMatchObject({
+      icon: 'i-simple-icons-vuedotjs',
+      color: '#42b883',
+      tier: 1,
+    })
+  })
+
+  it('is loaded by the generator without importing TypeScript at runtime', async () => {
+    const generator = await readFile(resolve('scripts/generate-og.mjs'), 'utf8')
+
+    expect(generator).toContain('import(\'../src/data/tag-icons.mjs\')')
+    expect(generator).not.toContain('import(\'../src/data/tag-icons.ts\')')
+  })
+})


### PR DESCRIPTION
## What changed

- Move the runtime tag-icon mapping into a plain JavaScript `tag-icons.mjs` module.
- Keep `tag-icons.ts` as the typed frontend-facing interface over the shared data.
- Make the OG generator import the JavaScript module instead of importing TypeScript directly.
- Add regression coverage for the Node-compatible data module and the generator import boundary.

## Root cause

The OG generator dynamically imported `src/data/tag-icons.ts`. In Cloudflare build environments running a Node version without native TypeScript stripping, that import throws `ERR_UNKNOWN_FILE_EXTENSION`. The generator caught the error and deliberately fell back to an empty icon list, so deployment succeeded but produced OG images without Logo watermarks.

This can be reproduced locally with TypeScript stripping disabled:

```sh
node --no-strip-types -e "import('./src/data/tag-icons.ts')"
```

The new `.mjs` module loads successfully under the same condition, so image correctness no longer depends on Cloudflare recognizing `.node-version`.

## Impact

Deployed OG images retain their event theme Logo watermarks even when the build runtime cannot execute TypeScript files directly.

## Validation

- `pnpm run lint --fix`
- `pnpm run typecheck`
- `CHOKIDAR_USEPOLLING=1 pnpm run test -- --run --maxWorkers=1 --no-file-parallelism` (271 tests passed)
- `pnpm run build`
- Generated all 33 OG images and visually verified the VueConf image contains Vue, Vite, and JavaScript watermarks.