### PR TITLE
fix: adding the official link for Google I/O Connect China 2026.

### DIFF
--- a/data/events/google-io-connect-china-2026.json
+++ b/data/events/google-io-connect-china-2026.json
@@ -1,15 +1,27 @@
 {
   "name": "Google I/O Connect China 2026",
-  "description": "Google 在中国上海举办的 I/O Connect 活动，探索 Android、AI、Chrome 和 Cloud 的最新技术。",
+  "description": "Google 在上海举办的开发者大会，汇集 Google 专家与开发者，聚焦 Android、AI、Chrome 和 Cloud 的最新技术、实践分享、互动演示与工作坊。",
   "startDate": "2026-08-12",
   "endDate": "2026-08-13",
   "city": "上海",
   "country": "中国",
   "format": "offline",
   "url": "https://ioconnectchina.googlecnapps.cn/",
-  "tags": ["android", "ai", "cloud", "conference"],
+  "tags": ["android", "ai", "chrome", "cloud", "conference"],
   "organizer": "Google",
   "sources": [
-    "https://ioconnectchina.googlecnapps.cn/"
+    "https://ioconnectchina.googlecnapps.cn/",
+    "https://ioconnectchina.googlecnapps.cn/sessions/",
+    "https://services.google.cn/fb/forms/2026googleioconnectcn/?utm-channel=officialwebsite"
+  ],
+  "links": [
+    {
+      "url": "https://services.google.cn/fb/forms/2026googleioconnectcn/?utm-channel=officialwebsite",
+      "label": "报名申请"
+    },
+    {
+      "url": "https://ioconnectchina.googlecnapps.cn/sessions/",
+      "label": "大会日程"
+    }
   ]
 }


### PR DESCRIPTION
## 修改内容

- 补充官方报名申请链接
- 补充官方大会议程链接
- 将实际用于核实信息的官网、议程页和报名页加入 `sources`
- 根据官网内容完善活动简介
- 补充 `chrome` 标签

## 核实结果

官方页面确认活动于 2026 年 8 月 12–13 日在上海线下举办，议题聚焦 Android、AI、Chrome 和 Cloud。报名采用申请审核制。

官网当前仅公开城市“上海”，未公开具体场馆，因此没有填写 `venue` 或 `coordinates`。官网展示“谷歌开发者”微信订阅号二维码，但没有提供适合写入数据文件的公开网页链接；直播或回放入口也尚未发布，因此未加入无法可靠核实的链接。

## 校验范围

仅修改：

- `data/events/google-io-connect-china-2026.json`

JSON 内容保持符合仓库模板结构。