### PR TITLE
feat: add Inclusion·外滩大会 2026

### DIFF
--- a/data/events/inclusion-bund-2026.json
+++ b/data/events/inclusion-bund-2026.json
@@ -1,0 +1,28 @@
+{
+  "name": "Inclusion·外滩大会 2026",
+  "description": "在上海举办的全球高级别前沿科技与金融科技盛会，由外滩大会组委会主办，自 2020 年起连续举办，涵盖主论坛、见解论坛、主题科技展、创新者舞台与科技人才招聘会等。",
+  "startDate": "2026-09-09",
+  "endDate": "2026-09-12",
+  "city": "上海",
+  "country": "中国",
+  "venue": "黄浦世博园区局门路689号（Inclusion外滩大会-1号门）",
+  "format": "offline",
+  "url": "https://www.inclusionconf.com/",
+  "tags": ["ai", "fintech", "conference"],
+  "organizer": "外滩大会组委会",
+  "sources": [
+    "https://www.inclusionconf.com/",
+    "https://www.inclusionconf.com/agenda",
+    "https://register.inclusionconf.com/"
+  ],
+  "links": [
+    {
+      "url": "https://register.inclusionconf.com/",
+      "label": "即刻参会（报名）"
+    },
+    {
+      "url": "https://www.inclusionconf.com/agenda",
+      "label": "大会议程"
+    }
+  ]
+}

--- a/src/data/tag-icons.mjs
+++ b/src/data/tag-icons.mjs
@@ -10,6 +10,7 @@ const cloud = /** @type {const} */ ({ icon: 'i-carbon-cloud', color: '#0ea5e9', 
 const robotics = /** @type {const} */ ({ icon: 'i-mdi-robot', color: '#64748b', colorDark: '#94a3b8', tier: 2 })
 const frontend = /** @type {const} */ ({ icon: 'i-carbon-application-web', color: '#0891b2', tier: 2 })
 const startup = /** @type {const} */ ({ icon: 'i-mdi-rocket-launch', color: '#f43f5e', tier: 2 })
+const fintech = /** @type {const} */ ({ icon: 'i-mdi-finance', color: '#0f766e', tier: 2 })
 const academia = /** @type {const} */ ({ icon: 'i-mdi-school', color: '#92400e', colorDark: '#d97706', tier: 2 })
 const python = /** @type {const} */ ({ icon: 'i-simple-icons-python', color: '#3776ab', tier: 1 })
 const google = /** @type {const} */ ({ icon: 'i-simple-icons-google', color: '#4285f4', tier: 1 })
@@ -58,6 +59,7 @@ export const tagIcons = /** @type {const} */ ({
   'startup': startup,
   'demoday': startup,
   'indiehacker': startup,
+  'fintech': fintech,
   'academic': academia,
   'computer-science': academia,
   'student': academia,


### PR DESCRIPTION
## 新增活动

添加 **Inclusion·外滩大会 2026**（`data/events/inclusion-bund-2026.json`）：

- 时间：2026-09-09 ～ 2026-09-12
- 地点：上海 · 黄浦世博园区局门路689号（1号门）
- 主办：外滩大会组委会
- 形式：线下
- 标签：`ai` / `fintech` / `conference`

## 配套改动

为 `fintech` 标签新增图标 `i-mdi-finance`（`src/data/tag-icons.mjs`），
该大会是「前沿科技 + 金融科技」盛会，`fintech` 是它的关键筛选词。

## 数据来源

- https://www.inclusionconf.com/ （官网首页：名称/时间/地点/主办方）
- https://www.inclusionconf.com/agenda （议程页）
- https://register.inclusionconf.com/ （报名页）

## 校验

- `pnpm test` 通过（60/61；唯一失败 `related.test.ts` 为仓库预先存在问题，与本次改动无关）
- `pnpm gen:ics` 正常生成