### PR TITLE
fix: pin now in relatedEvents tie-break test to make CI deterministic

### DIFF
--- a/test/related.test.ts
+++ b/test/related.test.ts
@@ -43,7 +43,8 @@ describe('relatedEvents', () => {
   it('breaks score ties by date proximity to the source event', () => {
     const near = make('near', { tags: ['vue'], city: '北京', startDate: '2026-08-10' })
     const far = make('far', { tags: ['vue'], city: '北京', startDate: '2027-03-01' })
-    expect(relatedEvents(self, [self, far, near]).map(e => e.id)).toEqual(['near', 'far'])
+    const now = new Date(2026, 7, 1) // 固定 now：让 near/far 都未结束，只测“日期距离”平局
+    expect(relatedEvents(self, [self, far, near], 4, now).map(e => e.id)).toEqual(['near', 'far'])
   })
 
   it('sorts ended events after upcoming ones regardless of score', () => {


### PR DESCRIPTION
<!-- 感谢贡献活动！如果只是新增 / 修改活动，按下面的清单确认即可。 -->

## 这个 PR 做了什么

- [ ] 新增活动
- [ ] 修改已有活动
- [x] 其他（功能 / 文档 / 修复）

修复 `relatedEvents` 的日期远近平局测试（`test/related.test.ts`）：之前调用没固定 `now`，在 2026-08-10 ~ 2027-03-01 窗口内会把 `near` 判为“已结束”而排到 `far` 后面，导致 CI 必红。固定 `now = new Date(2026, 7, 1)` 后测试变为确定性，全套 `pnpm test` 通过（61/61）。

## 活动信息（如适用）

不适用（本次为测试修复，非活动新增 / 修改）。

## 自查清单

- [ ] 文件名为英文小写、有辨识度（如 `vueconf-china-2026.json`）—— 不适用（未改活动数据）
- [ ] `startDate` 等日期为 `YYYY-MM-DD` 格式 —— 不适用
- [ ] `url` 指向官方来源，日期已核对 —— 不适用
- [ ] `tags` 全部小写，尽量复用已有标签 —— 不适用
