### PR TITLE
feat(data): add Grok Bot Meetup Shanghai

### DIFF
--- a/data/events/grok-bot-meetup-shanghai-2026.json
+++ b/data/events/grok-bot-meetup-shanghai-2026.json
@@ -1,0 +1,21 @@
+{
+  "name": "Grok Bot Meetup Shanghai",
+  "description": "面向 Grok Bot 用户与感兴趣开发者的线下交流活动，安排包括交流破冰和分享 / Workshop。报名需经主办方审核。",
+  "startDate": "2026-10-17",
+  "city": "上海",
+  "country": "中国",
+  "format": "offline",
+  "url": "https://luma.com/spacexai-kh2x",
+  "tags": ["ai", "agentic-ai", "meetup"],
+  "organizer": "SpaceXAI for Shanghai, China",
+  "sources": [
+    "https://luma.com/spacexai-kh2x",
+    "https://cursor.com/community",
+    "https://forum.cursor.com/t/new-event-grok-bot-meetup-shanghai/170454",
+    "https://x.com/MaiYangAI/status/2096074726305362387"
+  ],
+  "links": [
+    { "url": "https://luma.com/spacexai-shanghai", "label": "上海社区活动日历" },
+    { "url": "https://forum.cursor.com/t/new-event-grok-bot-meetup-shanghai/170454", "label": "Cursor 社区公告" }
+  ]
+}


### PR DESCRIPTION
## 概述

添加 2026 年 Grok Bot Meetup Shanghai 活动数据。

## 核实信息

- 日期：2026-10-17
- 城市：上海
- 形式：线下
- 主办方：SpaceXAI for Shanghai, China
- 活动内容：交流破冰、分享 / Workshop
- 报名方式：Luma 预报名，需审核

信息由 Luma 活动页、SpaceXAI 上海活动日历、Cursor 官方社区列表及相关官方公告交叉核对。

## 暂未填写

活动场馆仅对审核通过的报名者公开，因此省略 `venue` 和 `coordinates`。