### PR TITLE
test: pin date in related event proximity test

### DIFF
--- a/test/related.test.ts
+++ b/test/related.test.ts
@@ -41,9 +41,10 @@ describe('relatedEvents', () => {
   })
 
   it('breaks score ties by date proximity to the source event', () => {
+    const now = new Date(2026, 7, 1)
     const near = make('near', { tags: ['vue'], city: '北京', startDate: '2026-08-10' })
     const far = make('far', { tags: ['vue'], city: '北京', startDate: '2027-03-01' })
-    expect(relatedEvents(self, [self, far, near]).map(e => e.id)).toEqual(['near', 'far'])
+    expect(relatedEvents(self, [self, far, near], 4, now).map(e => e.id)).toEqual(['near', 'far'])
   })
 
   it('sorts ended events after upcoming ones regardless of score', () => {


### PR DESCRIPTION
## 问题

`breaks score ties by date proximity to the source event` 使用了固定的 2026 年活动日期，却依赖运行测试时的真实当前日期。

从 2026-08-10 开始，`near` 会被判断为已结束，而 `far` 仍是未来活动。根据 `relatedEvents` 的既定排序规则，未来活动应优先于已结束活动，因此断言随时间失效。

## 修复

为该测试传入固定的 `now`（2026-08-01），确保两个候选活动均为未来活动，使测试只验证其名称描述的“同分时按日期接近程度排序”行为。

仅修改测试，不改变生产逻辑。