### PR TITLE
feat: 添加德邻杯 2026 AI 创业大赛

### DIFF
--- a/data/events/delin-cup-2026.json
+++ b/data/events/delin-cup-2026.json
@@ -1,0 +1,20 @@
+{
+  "name": "德邻杯｜2026 AI 创业大赛",
+  "description": "面向以 AI 应用或 AI 硬件解决真实场景问题的创业团队。报名项目经评审后，60 支团队将进入深圳线下决赛，优胜团队可进入为期 10 周的 Delin Residency 驻场共创。",
+  "startDate": "2026-10-15",
+  "endDate": "2026-10-16",
+  "city": "深圳",
+  "country": "中国",
+  "format": "offline",
+  "url": "https://delincapital.com.cn/delin-cup.html",
+  "tags": ["ai", "startup", "competition"],
+  "organizer": "德邻资本",
+  "sources": [
+    "https://delincapital.com.cn/delin-cup.html",
+    "https://mp.weixin.qq.com/s/eZDzbsoQyR_i3SIy6ersEw"
+  ],
+  "links": [
+    { "url": "https://delincapital.com.cn/apply.html", "label": "在线报名（截止 9 月 30 日）" },
+    { "url": "https://x.com/Delincapital8", "label": "德邻资本 X" }
+  ]
+}


### PR DESCRIPTION
## 概述

添加「德邻杯｜2026 AI 创业大赛」活动数据。

- 深圳线下决赛：2026 年 10 月 15–16 日
- 报名截止：2026 年 9 月 30 日
- 主办方：德邻资本
- 补充官方活动页、报名页、微信公告和 X 账号

## 来源

- https://delincapital.com.cn/delin-cup.html
- https://mp.weixin.qq.com/s/eZDzbsoQyR_i3SIy6ersEw

官网说明具体赛程和场地将在入围通知中公布，因此未填写场馆与坐标。

## 校验

- JSON 解析通过
- 活动必填字段、日期格式、活动形式和小写标签检查通过
- `git diff --check` 通过

完整 `pnpm test` 未在当前环境运行：安装依赖时被供应链安全策略拦截，未修改锁文件或绕过策略。