### PR TITLE
data: add MAÑANA 明日公园 2026

### DIFF
--- a/data/events/manana-tomorrow-park-2026.json
+++ b/data/events/manana-tomorrow-park-2026.json
@@ -1,0 +1,17 @@
+{
+  "name": "MAÑANA 明日公园 2026",
+  "description": "小红书发起的科技生活类线下文化活动，以一场为期 72 小时的开放性未来实验，汇集科技体验、创意市集、艺术、音乐与共创内容。",
+  "startDate": "2026-10-23",
+  "endDate": "2026-10-25",
+  "city": "海口",
+  "country": "中国",
+  "venue": "天空之山驿站",
+  "format": "offline",
+  "url": "https://hkslww.com/content/19658.html",
+  "tags": ["ai", "maker", "expo"],
+  "organizer": "小红书",
+  "sources": [
+    "https://hkslww.com/content/19658.html",
+    "https://gjcbyys.hainanu.edu.cn/info/1426/12012.htm"
+  ]
+}


### PR DESCRIPTION
## 活动

新增 **MAÑANA 明日公园 2026**：

- 日期：2026-10-23 至 2026-10-25
- 城市：海口
- 场地：天空之山驿站
- 主办方：小红书
- 形式：线下

## 来源

- 海口旅游活动发布页
- 海南大学国际传播与艺术学院项目合作公告

## 说明

- 未填写坐标：当前可检索地图坐标并非可靠的 WGS-84 数据。
- 未添加 `links`：尚未找到可独立验证的官方报名、议程或直播链接。
- JSON 已重新读取并解析验证。