### PR TITLE
data: add September 2026 developer events

### DIFF
--- a/data/events/arm-create-shenzhen-2026.json
+++ b/data/events/arm-create-shenzhen-2026.json
@@ -1,0 +1,15 @@
+{
+  "name": "Arm Create 2026 深圳站",
+  "description": "Arm 年度开发者活动深圳站，围绕从云端到边缘的智能体 AI，涵盖 Armv9、端侧 AI、游戏渲染、机器人与性能优化等技术方向。",
+  "startDate": "2026-09-11",
+  "city": "深圳",
+  "country": "中国",
+  "venue": "深圳湾万丽酒店",
+  "format": "offline",
+  "url": "https://developer.arm.com/",
+  "tags": ["arm", "ai", "edge-ai", "robotics", "conference"],
+  "organizer": "Arm",
+  "sources": [
+    "https://developer.arm.com/"
+  ]
+}

--- a/data/events/kuaishou-data-agent-202609.json
+++ b/data/events/kuaishou-data-agent-202609.json
@@ -1,0 +1,15 @@
+{
+  "name": "快手技术沙龙：Data Agent——数据生产与智能决策新范式",
+  "description": "结合快手电商、A/B 实验平台等真实业务场景，分享快手技术团队在数据智能体方向的技术探索、产品建设与业务落地实践。",
+  "startDate": "2026-09-19",
+  "city": "北京",
+  "country": "中国",
+  "venue": "快手公司 T12-101",
+  "format": "offline",
+  "url": "https://mp.weixin.qq.com/s/eLM_PvHuiodMTM6n31WnkA",
+  "tags": ["ai", "agent", "data", "meetup"],
+  "organizer": "快手技术",
+  "sources": [
+    "https://mp.weixin.qq.com/s/eLM_PvHuiodMTM6n31WnkA"
+  ]
+}

--- a/data/events/pycon-china-2026.json
+++ b/data/events/pycon-china-2026.json
@@ -1,6 +1,6 @@
 {
   "name": "PyCon China 2026（上海站）",
-  "description": "中国 Python 社区年度大会上海场，主题围绕 AI 时代下的 Python 应用与生态展开；深圳场日期待官宣。",
+  "description": "中国 Python 社区年度大会上海场，主题围绕 AI 时代下的 Python 应用与生态展开。",
   "startDate": "2026-09-05",
   "city": "上海",
   "country": "中国",

--- a/data/events/pycon-china-shenzhen-2026.json
+++ b/data/events/pycon-china-shenzhen-2026.json
@@ -1,0 +1,29 @@
+{
+  "name": "PyCon China 2026（深圳站）",
+  "description": "中国 Python 社区年度大会深圳场，围绕 AI 时代的 Python 应用与生态，覆盖智能体、大模型、物理 AI、数据科学、Web 开发、云原生与自动化。",
+  "startDate": "2026-09-13",
+  "city": "深圳",
+  "country": "中国",
+  "venue": "华润城万象天地北京银行总部 10 楼创客中心",
+  "format": "offline",
+  "url": "https://cn.pycon.org/2026/",
+  "tags": ["python", "pycon", "ai", "opensource", "conference"],
+  "organizer": "PyCon China 组委会",
+  "sources": [
+    "https://cn.pycon.org/2026/"
+  ],
+  "links": [
+    {
+      "url": "https://x.com/PyConChina"
+    },
+    {
+      "url": "https://github.com/PyConChina"
+    },
+    {
+      "url": "https://space.bilibili.com/474764697"
+    },
+    {
+      "url": "https://weibo.com/PyConCN"
+    }
+  ]
+}

--- a/data/events/tencent-cloud-agent-infra-shanghai-202609.json
+++ b/data/events/tencent-cloud-agent-infra-shanghai-202609.json
@@ -1,0 +1,14 @@
+{
+  "name": "腾讯云架构师城市沙龙：AI Agent Infra——让智能体跑得更稳",
+  "description": "面向智能体工程实践的技术沙龙，讨论智能体基础设施、记忆系统及其在真实产品与团队中的落地。",
+  "startDate": "2026-09-19",
+  "city": "上海",
+  "country": "中国",
+  "format": "offline",
+  "url": "https://developer.cloud.tencent.com/salon/salon-2513",
+  "tags": ["ai", "agent", "cloud", "meetup"],
+  "organizer": "腾讯云开发者社区",
+  "sources": [
+    "https://developer.cloud.tencent.com/salon/salon-2513"
+  ]
+}


### PR DESCRIPTION
## 活动

- Arm Create 2026 深圳站
- PyCon China 2026（深圳站）
- 快手 Data Agent 技术沙龙
- 腾讯云 AI Agent Infra 上海沙龙

同时移除 PyCon China 上海站文件中已经过时的“深圳场日期待官宣”。

## 来源

优先采用 Arm、PyCon China、快手技术及腾讯云开发者社区的官方活动页面。未能可靠核实的坐标和腾讯云沙龙具体场馆保持为空。

## 验证

- 新增和修改的 JSON 均已通过 `JSON.parse` 检查
- 当前执行环境无法联网安装 pnpm 依赖，因此未能在本地运行完整 `pnpm test`，请以 CI 为准