### PR TITLE
data: add September 2026 creator events in Shanghai

### DIFF
--- a/data/events/open-agi-builder-day-shanghai-202609.json
+++ b/data/events/open-agi-builder-day-shanghai-202609.json
@@ -1,0 +1,22 @@
+{
+  "name": "Open AGI Builder Day 上海站",
+  "description": "面向 AI 开发者、智能体产品团队与生态参与者的线下交流活动，围绕开源 AGI、产品实践与生态投资展开分享。",
+  "startDate": "2026-09-19",
+  "city": "上海",
+  "country": "中国",
+  "venue": "盛邦国际大厦 2F",
+  "format": "offline",
+  "url": "https://luma.com/88etf2ms",
+  "tags": ["ai", "agent", "opensource", "meetup"],
+  "organizer": "Sentient Foundation / 聚翼汇智科技",
+  "sources": [
+    "https://x.com/sentient_zh/status/2094760855212831210",
+    "https://luma.com/88etf2ms"
+  ],
+  "links": [
+    {
+      "url": "https://x.com/sentient_found",
+      "label": "Sentient Foundation"
+    }
+  ]
+}

--- a/data/events/s-tron-shanghai-2026.json
+++ b/data/events/s-tron-shanghai-2026.json
@@ -1,0 +1,23 @@
+{
+  "name": "S 创上海 2026 (S-Tron Shanghai 2026)",
+  "description": "汇聚科技创业者、投资人、企业与创作者的创新大会，包含主题演讲、先锋对话、初创路演、品牌体验、项目对接和创作者展位。",
+  "startDate": "2026-09-22",
+  "endDate": "2026-09-23",
+  "city": "上海",
+  "country": "中国",
+  "venue": "上海西岸艺术中心 A 馆",
+  "format": "offline",
+  "url": "https://www.s-union.cn/show_iframe_component/1609720?source=live_site",
+  "tags": ["startup", "ai", "creator", "conference"],
+  "organizer": "S 创中国",
+  "sources": [
+    "https://www.s-union.cn/show_iframe_component/1609720?source=live_site",
+    "https://www.eventbrite.com/e/s-tron-shanghai-2026-tickets-1979297181150"
+  ],
+  "links": [
+    {
+      "url": "https://www.eventbrite.com/e/s-tron-shanghai-2026-tickets-1979297181150",
+      "label": "购票"
+    }
+  ]
+}


### PR DESCRIPTION
## 活动

- Open AGI Builder Day 上海站
- S 创上海 2026

## 来源

活动日期、地点和主办方分别由 Sentient 官方账号、Luma 报名页、S 创活动页与购票页交叉核实。未填写无法可靠确认的坐标。

## 验证

新增 JSON 已通过 `JSON.parse` 检查；当前环境无法联网安装 pnpm 依赖，完整测试请以 CI 为准。