### PR TITLE
data: add autumn 2026 hackathons

### DIFF
--- a/data/events/anker-hackathon-2026.json
+++ b/data/events/anker-hackathon-2026.json
@@ -1,0 +1,16 @@
+{
+  "name": "Anker 首届黑客松挑战赛",
+  "description": "安克创新围绕智能录音、智能安防、充电储能与智能服务四个真实业务方向举办的 AI 原生软硬件黑客松，先在线上提交预赛作品，入围团队参加深圳现场决赛。",
+  "startDate": "2026-09-07",
+  "endDate": "2026-10-17",
+  "city": "深圳",
+  "country": "中国",
+  "venue": "安克大楼",
+  "format": "hybrid",
+  "url": "https://career.anker.com.cn/hackathon/",
+  "tags": ["ai", "hardware", "hackathon"],
+  "organizer": "安克创新",
+  "sources": [
+    "https://career.anker.com.cn/hackathon/"
+  ]
+}

--- a/data/events/gosim-agentic-factory-hackathon-2026.json
+++ b/data/events/gosim-agentic-factory-hackathon-2026.json
@@ -1,0 +1,22 @@
+{
+  "name": "GOSIM Agentic Factory Hackathon 2026",
+  "description": "面向全球开发者的智能体软件工程竞赛，通过线上资格赛和大奖赛构建可完成需求理解、代码生成、测试验证与交付任务的软件工程智能体，并在 GOSIM Shenzhen 展示成果。",
+  "startDate": "2026-09-07",
+  "endDate": "2026-10-17",
+  "city": "深圳",
+  "country": "中国",
+  "format": "hybrid",
+  "url": "https://create.gosim.org/",
+  "tags": ["ai", "agent", "opensource", "hackathon"],
+  "organizer": "GOSIM Foundation / OAIC",
+  "sources": [
+    "https://create.gosim.org/",
+    "https://shenzhen2026.gosim.org/"
+  ],
+  "links": [
+    {
+      "url": "https://shenzhen2026.gosim.org/",
+      "label": "GOSIM Shenzhen 2026"
+    }
+  ]
+}

--- a/data/events/moonbit-hackathon-202609.json
+++ b/data/events/moonbit-hackathon-202609.json
@@ -1,0 +1,21 @@
+{
+  "name": "2026 MoonBit 九月黑客松",
+  "description": "面向所有开发者的线上开源黑客松，使用 MoonBit 构建并公开参赛项目；报名与项目验收均于 9 月 24 日截止。",
+  "startDate": "2026-09-01",
+  "endDate": "2026-09-24",
+  "city": "线上",
+  "country": "中国",
+  "format": "online",
+  "url": "https://moonbitlang.github.io/Hackathon2026/",
+  "tags": ["moonbit", "opensource", "hackathon"],
+  "organizer": "MoonBit",
+  "sources": [
+    "https://moonbitlang.github.io/Hackathon2026/"
+  ],
+  "links": [
+    {
+      "url": "https://github.com/moonbitlang",
+      "label": "MoonBit GitHub"
+    }
+  ]
+}


### PR DESCRIPTION
## 活动

- Anker 首届黑客松挑战赛
- GOSIM Agentic Factory Hackathon 2026
- 2026 MoonBit 九月黑客松

## 来源

仅采用安克招聘官网、GOSIM 官方站与 MoonBit 官方 GitHub Pages。活动横跨线上阶段和线下决赛时采用 `hybrid`；无法可靠确认的坐标保持为空。

## 验证

新增 JSON 已通过 `JSON.parse` 检查；当前环境无法联网安装 pnpm 依赖，完整测试请以 CI 为准。