### PR TITLE
data: add 2026 Inclusion·外滩大会

### DIFF
--- a/data/events/inclusion-bund-conference-2026.json
+++ b/data/events/inclusion-bund-conference-2026.json
@@ -1,0 +1,21 @@
+{
+  "name": "2026 Inclusion·外滩大会",
+  "description": "以“共创AI新经济”为主题的前沿科技与金融科技大会，设有主论坛、见解论坛、主题科技展、开发者日、创新赛及AI艺术节等活动。",
+  "startDate": "2026-09-09",
+  "endDate": "2026-09-12",
+  "city": "上海",
+  "country": "中国",
+  "venue": "上海黄浦世博园区",
+  "format": "offline",
+  "url": "https://www.inclusionconf.com/",
+  "tags": ["ai", "conference", "expo"],
+  "organizer": "外滩大会组委会",
+  "sources": [
+    "https://www.inclusionconf.com/",
+    "https://register.inclusionconf.com/"
+  ],
+  "links": [
+    { "url": "https://register.inclusionconf.com/", "label": "报名与参会服务" },
+    { "url": "https://www.inclusionconf.com/?openLogin=1", "label": "大会议程" }
+  ]
+}


### PR DESCRIPTION
## 概述

新增 2026 Inclusion·外滩大会活动数据。

## 已核实信息

- 日期：2026-09-09 至 2026-09-12
- 城市及场地：上海黄浦世博园区
- 形式：线下
- 主办方：外滩大会组委会
- 主题与主要活动：共创AI新经济；主论坛、见解论坛、科技展、开发者日、创新赛及AI艺术节

## 来源

- https://www.inclusionconf.com/
- https://register.inclusionconf.com/

## 校验

- JSON 解析通过
- `git diff --check` 通过
- 本地工作区缺少依赖，且受网络权限限制无法执行 `pnpm install`，因此未在本地运行完整 `pnpm test`；等待 CI 完成完整校验。