### PR TITLE
data: add AWS Community Day Shenzhen and Chengdu AIOps Day 2026

### DIFF
--- a/data/events/aiops-agentops-day-chengdu-2026.json
+++ b/data/events/aiops-agentops-day-chengdu-2026.json
@@ -1,0 +1,16 @@
+{
+  "name": "AIOps Day 成都站：可观测性、AIOps 与 AgentOps 闭门交流会",
+  "description": "聚焦 Observability × AI Agent 融合实践的闭门交流会，亚马逊云科技、观测云、NebulaGraph 一线专家分享 AI for Ops 与 Ops for AI 的双向重塑。50 人闭门邀请制。",
+  "startDate": "2026-09-18",
+  "endDate": "2026-09-18",
+  "city": "成都",
+  "country": "中国",
+  "venue": "亚马逊云科技成都办公室（武侯区益州大道中段 1999 号银泰城写字楼 4 号楼 19 层）",
+  "format": "offline",
+  "url": "https://awscommunity.cn/events/aiops-day-%E5%8F%AF%E8%A7%82%E6%B5%8B%E6%80%A7aiops-%E4%B8%8E-agentops-%E9%97%AD%E9%97%A8%E4%BA%A4%E6%B5%81%E4%BC%9A-7876684283200/",
+  "tags": ["aws", "aiops", "agentops", "observability", "meetup"],
+  "organizer": "亚马逊云科技 User Group",
+  "sources": [
+    "https://awscommunity.cn/events/aiops-day-%E5%8F%AF%E8%A7%82%E6%B5%8B%E6%80%A7aiops-%E4%B8%8E-agentops-%E9%97%AD%E9%97%A8%E4%BA%A4%E6%B5%81%E4%BC%9A-7876684283200/"
+  ]
+}

--- a/data/events/aws-community-day-shenzhen-2026.json
+++ b/data/events/aws-community-day-shenzhen-2026.json
@@ -1,0 +1,17 @@
+{
+  "name": "AWS Community Day Shenzhen 2026",
+  "description": "由 AWS 用户社群主导的年度技术大会深圳场，汇聚社区力量，涵盖云计算、AI/ML 等主题的技术分享与实践案例。",
+  "startDate": "2026-10-17",
+  "endDate": "2026-10-17",
+  "city": "深圳",
+  "country": "中国",
+  "venue": "雪花科技大厦 6 楼（宝安区雪花路 1 号，地铁 5 号线兴东站 B 口）",
+  "format": "offline",
+  "url": "https://2026-autumn.awscommunityday.cn/",
+  "tags": ["aws", "cloud", "community", "conference"],
+  "organizer": "亚马逊云科技 User Group",
+  "sources": [
+    "https://2026-autumn.awscommunityday.cn/",
+    "https://awscommunity.cn/events/community-day-2026-%E6%B7%B1%E5%9C%B3-9872593983600/"
+  ]
+}


### PR DESCRIPTION
   ## 这个 PR 做了什么

   - [x] 新增活动
   - [ ] 修改已有活动
   - [ ] 其他（功能 / 文档 / 修复）

   ## 活动信息（如适用）

   - 活动名称：AWS Community Day Shenzhen 2026（2026-10-17 · 深圳）
   - 官方链接：https://2026-autumn.awscommunityday.cn/
   - 文件：`data/events/aws-community-day-shenzhen-2026.json`

   - 活动名称：AIOps Day 成都站：可观测性、AIOps 与 AgentOps 闭门交流会（2026-09-18 · 成都）
   - 官方链接：https://awscommunity.cn/events/aiops-day-%E5%8F%AF%E8%A7%82%E6%B5%8B%E6%80%A7aiops-%E4%B8%8E-agentops-%E9%97%AD%E9%97%A8%E4%BA%A4%E6%B5%81%E4%BC%9A-7876684283200/
   - 文件：`data/events/aiops-agentops-day-chengdu-2026.json`

   ## 自查清单

   - [x] 文件名为英文小写、有辨识度（如 `vueconf-china-2026.json`）
   - [x] `startDate` 等日期为 `YYYY-MM-DD` 格式
   - [x] `url` 指向官方来源，日期已核对
   - [x] `tags` 全部小写，尽量复用已有标签