### PR TITLE
feat: add giscus discussions to event detail pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,24 @@ pnpm test         # 运行测试
 ## 技术栈
 
 Vue 3 · Vite · UnoCSS · vue-router（文件路由）。活动数据存放在 `data/events/*.json`，构建时一并生成 [iCalendar](https://datatracker.ietf.org/doc/html/rfc5545) 订阅源。
+
+## Event comments
+
+Event pages embed [giscus](https://giscus.app/) after related events. The widget
+loads only in the browser and lazily loads its iframe; the rest of each page
+remains statically rendered. Comments require a GitHub account.
+
+- Enable Discussions and install the [giscus GitHub App](https://github.com/apps/giscus)
+  for this repository only.
+- Use the **Event comments** category with the **Announcement** format. Public
+  repository and category IDs live in `src/config.ts`; no client secret is needed.
+- Each thread uses the strict key `event:<event-id>`. Keep event filenames stable;
+  renaming one requires migrating its discussion mapping, including the strict
+  matching hash. Titles, domains and `.html` URL variants do not change the key.
+- The `giscus:backlink` meta tag points discussions to the production canonical URL.
+- Moderate comments in GitHub Discussions. The first comment or reaction creates
+  the thread; a GitHub search with no results is normal before that happens.
+
+Before deploying a fork, replace the repository/category IDs with your own.
+Verify desktop/mobile layout, theme changes, navigation between events, and the
+GitHub fallback link. Do not post test comments to real event discussions.

--- a/components.d.ts
+++ b/components.d.ts
@@ -14,6 +14,7 @@ declare module 'vue' {
     CalendarView: typeof import('./src/components/CalendarView.vue')['default']
     ContributionMenu: typeof import('./src/components/ContributionMenu.vue')['default']
     EventCard: typeof import('./src/components/EventCard.vue')['default']
+    EventComments: typeof import('./src/components/EventComments.vue')['default']
     EventDetailCard: typeof import('./src/components/EventDetailCard.vue')['default']
     EventMapEmbed: typeof import('./src/components/EventMapEmbed.vue')['default']
     EventShareButtons: typeof import('./src/components/EventShareButtons.vue')['default']

--- a/components.d.ts
+++ b/components.d.ts
@@ -19,6 +19,7 @@ declare module 'vue' {
     EventMapEmbed: typeof import('./src/components/EventMapEmbed.vue')['default']
     EventShareButtons: typeof import('./src/components/EventShareButtons.vue')['default']
     FilterBar: typeof import('./src/components/FilterBar.vue')['default']
+    RelatedEvents: typeof import('./src/components/RelatedEvents.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     TheHeader: typeof import('./src/components/TheHeader.vue')['default']

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "postinstall": "npx simple-git-hooks"
   },
   "dependencies": {
+    "@giscus/vue": "catalog:frontend",
     "@unhead/vue": "catalog:frontend",
     "@vueuse/core": "catalog:frontend",
     "leaflet": "catalog:frontend",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ catalogs:
       specifier: ^3.2.5
       version: 3.2.5
   frontend:
+    '@giscus/vue':
+      specifier: 3.1.1
+      version: 3.1.1
     '@unhead/vue':
       specifier: ^2.1.16
       version: 2.1.16
@@ -116,6 +119,9 @@ importers:
 
   .:
     dependencies:
+      '@giscus/vue':
+        specifier: catalog:frontend
+        version: 3.1.1(vue@3.5.29(typescript@5.9.3))
       '@unhead/vue':
         specifier: catalog:frontend
         version: 2.1.16(vue@3.5.29(typescript@5.9.3))
@@ -221,6 +227,32 @@ importers:
         version: 3.2.5(typescript@5.9.3)
 
 packages:
+
+  '@giscus/vue@3.1.1':
+    resolution: {integrity: sha512-xgsc93MibRQ0d1glBxN1BrEREHTIf3BPYs/3R+UZHNqawFFoWBV6iJ7uVCXMqoEKZdE2c78B3aKt5gfGqo8I5A==}
+    peerDependencies:
+      vue: '>=3.2.0'
+
+  '@lit-labs/ssr-dom-shim@1.6.0':
+    resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
+
+  '@lit/reactive-element@2.1.2':
+    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  giscus@1.6.0:
+    resolution: {integrity: sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==}
+
+  lit-element@4.2.2:
+    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
+
+  lit-html@3.3.3:
+    resolution: {integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==}
+
+  lit@3.3.3:
+    resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
   '@aashutoshrathi/word-wrap@1.2.6':
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
@@ -3845,6 +3877,39 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@giscus/vue@3.1.1(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      giscus: 1.6.0
+      vue: 3.5.29(typescript@5.9.3)
+
+  '@lit-labs/ssr-dom-shim@1.6.0': {}
+
+  '@lit/reactive-element@2.1.2':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
+
+  '@types/trusted-types@2.0.7': {}
+
+  giscus@1.6.0:
+    dependencies:
+      lit: 3.3.3
+
+  lit-element@4.2.2:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
+      '@lit/reactive-element': 2.1.2
+      lit-html: 3.3.3
+
+  lit-html@3.3.3:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@3.3.3:
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit-element: 4.2.2
+      lit-html: 3.3.3
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,7 @@ catalogs:
     vitest: ^4.0.18
     vue-tsc: ^3.2.5
   frontend:
+    '@giscus/vue': 3.1.1
     # Pinned to match vite-ssg's bundled @unhead/vue so pnpm dedupes to a
     # single head instance — otherwise components' useHead/useSeoMeta calls
     # register with a different head context than the one vite-ssg renders

--- a/src/components/EventCard.vue
+++ b/src/components/EventCard.vue
@@ -89,8 +89,13 @@ const taggedChips = computed(() =>
 </template>
 
 <style scoped>
-/* Desaturate the complete palette without changing content, decoration or layout. */
-.event-card-muted {
-  filter: grayscale(1);
+/* Limit the resting palette to foreground details; keep original surfaces and hover colors. */
+.event-card-muted:not(:hover):not(:focus-visible) h3,
+.event-card-muted:not(:hover):not(:focus-visible) .ev-icon-tinted {
+  color: inherit;
+}
+
+.event-card-muted:not(:hover):not(:focus-visible) .ev-watermark {
+  --ev-c: currentColor;
 }
 </style>

--- a/src/components/EventCard.vue
+++ b/src/components/EventCard.vue
@@ -3,7 +3,12 @@ import type { NormalizedEvent } from '~/types'
 import { resolveEventTheme, tagIconFor } from '~/utils/eventTheme'
 import { formatDateRange, isPast } from '~/utils/format'
 
-const { event } = defineProps<{ event: NormalizedEvent }>()
+const { event, variant = 'default' } = defineProps<{
+  event: NormalizedEvent
+  variant?: 'default' | 'compact'
+}>()
+
+const compact = computed(() => variant === 'compact')
 
 const formatLabel: Record<NormalizedEvent['format'], string> = {
   offline: '线下',
@@ -22,7 +27,7 @@ const themeStyle = computed(() => theme.value && {
 })
 
 const taggedChips = computed(() =>
-  event.tags.map(tag => ({ tag, def: tagIconFor(tag) })),
+  (compact.value ? event.tags.slice(0, 2) : event.tags).map(tag => ({ tag, def: tagIconFor(tag) })),
 )
 </script>
 
@@ -32,11 +37,11 @@ const taggedChips = computed(() =>
     class="card"
     p-4
     block
-    :class="[past ? 'op60 hover:op100' : '', theme ? 'ev-themed' : '']"
+    :class="[past ? 'op60 hover:op100' : '', compact ? 'event-card-compact' : theme ? 'ev-themed' : '']"
     :style="themeStyle"
   >
     <div flex="~ items-start justify-between gap-3">
-      <h3 text-lg leading-snug font-600 :class="theme ? 'ev-title-themed' : ''">
+      <h3 leading-snug font-600 :class="compact ? 'text-base' : ['text-lg', theme ? 'ev-title-themed' : '']">
         {{ event.name }}
       </h3>
       <span text-xs mt-1 op70 shrink-0>{{ formatLabel[event.format] }}</span>
@@ -50,12 +55,12 @@ const taggedChips = computed(() =>
         <div i-carbon-location shrink-0 />
         {{ event.city }}<template v-if="event.country !== '中国'"> · {{ event.country }}</template>
       </span>
-      <span v-if="event.organizer" flex="~ items-center gap-1">
+      <span v-if="event.organizer && !compact" flex="~ items-center gap-1">
         <div i-carbon-group shrink-0 /> {{ event.organizer }}
       </span>
     </div>
 
-    <p v-if="event.description" text-sm leading-relaxed mt-2 op70>
+    <p v-if="event.description" text-sm leading-relaxed mt-2 op70 :class="{ 'compact-description': compact }">
       {{ event.description }}
     </p>
 
@@ -68,12 +73,12 @@ const taggedChips = computed(() =>
 
         text-xs px-2 py-0.5 rounded op80 inline-flex gap-1 items-center
       >
-        <div v-if="def" :class="def.icon" class="ev-icon-tinted" text-xs :style="{ '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }" />
+        <div v-if="def" :class="[def.icon, compact ? 'text-gray-500 dark:text-gray-400' : 'ev-icon-tinted']" text-xs :style="compact ? undefined : { '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }" />
         {{ tag }}
       </span>
     </div>
 
-    <div v-if="theme" class="ev-watermark" aria-hidden="true">
+    <div v-if="theme && !compact" class="ev-watermark" aria-hidden="true">
       <div
         v-for="def in theme.icons.slice(1).reverse()"
         :key="def.icon"
@@ -84,3 +89,26 @@ const taggedChips = computed(() =>
     </div>
   </RouterLink>
 </template>
+
+<style scoped>
+.event-card-compact h3 {
+  transition: color 150ms;
+}
+
+.event-card-compact:hover h3,
+.event-card-compact:focus-visible h3 {
+  color: var(--ev-color, #0f766e);
+}
+
+html.dark .event-card-compact:hover h3,
+html.dark .event-card-compact:focus-visible h3 {
+  color: var(--ev-color-dark, #2dd4bf);
+}
+
+.compact-description {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+}
+</style>

--- a/src/components/EventCard.vue
+++ b/src/components/EventCard.vue
@@ -89,7 +89,15 @@ const taggedChips = computed(() =>
 </template>
 
 <style scoped>
-/* Limit the resting palette to foreground details; keep original surfaces and hover colors. */
+/* Keep the original background and interaction colors while neutralizing resting accents. */
+.event-card-muted:not(:hover):not(:focus-visible) {
+  border-color: var(--colors-gray-200);
+}
+
+html.dark .event-card-muted:not(:hover):not(:focus-visible) {
+  border-color: var(--colors-gray-800);
+}
+
 .event-card-muted:not(:hover):not(:focus-visible) h3,
 .event-card-muted:not(:hover):not(:focus-visible) .ev-icon-tinted {
   color: inherit;

--- a/src/components/EventCard.vue
+++ b/src/components/EventCard.vue
@@ -5,10 +5,8 @@ import { formatDateRange, isPast } from '~/utils/format'
 
 const { event, variant = 'default' } = defineProps<{
   event: NormalizedEvent
-  variant?: 'default' | 'compact'
+  variant?: 'default' | 'muted'
 }>()
-
-const compact = computed(() => variant === 'compact')
 
 const formatLabel: Record<NormalizedEvent['format'], string> = {
   offline: '线下',
@@ -27,7 +25,7 @@ const themeStyle = computed(() => theme.value && {
 })
 
 const taggedChips = computed(() =>
-  (compact.value ? event.tags.slice(0, 2) : event.tags).map(tag => ({ tag, def: tagIconFor(tag) })),
+  event.tags.map(tag => ({ tag, def: tagIconFor(tag) })),
 )
 </script>
 
@@ -37,11 +35,11 @@ const taggedChips = computed(() =>
     class="card"
     p-4
     block
-    :class="[past ? 'op60 hover:op100' : '', compact ? 'event-card-compact' : theme ? 'ev-themed' : '']"
+    :class="[past ? 'op60 hover:op100' : '', theme ? 'ev-themed' : '', { 'event-card-muted': variant === 'muted' }]"
     :style="themeStyle"
   >
     <div flex="~ items-start justify-between gap-3">
-      <h3 leading-snug font-600 :class="compact ? 'text-base' : ['text-lg', theme ? 'ev-title-themed' : '']">
+      <h3 text-lg leading-snug font-600 :class="theme ? 'ev-title-themed' : ''">
         {{ event.name }}
       </h3>
       <span text-xs mt-1 op70 shrink-0>{{ formatLabel[event.format] }}</span>
@@ -55,12 +53,12 @@ const taggedChips = computed(() =>
         <div i-carbon-location shrink-0 />
         {{ event.city }}<template v-if="event.country !== '中国'"> · {{ event.country }}</template>
       </span>
-      <span v-if="event.organizer && !compact" flex="~ items-center gap-1">
+      <span v-if="event.organizer" flex="~ items-center gap-1">
         <div i-carbon-group shrink-0 /> {{ event.organizer }}
       </span>
     </div>
 
-    <p v-if="event.description" text-sm leading-relaxed mt-2 op70 :class="{ 'compact-description': compact }">
+    <p v-if="event.description" text-sm leading-relaxed mt-2 op70>
       {{ event.description }}
     </p>
 
@@ -73,12 +71,12 @@ const taggedChips = computed(() =>
 
         text-xs px-2 py-0.5 rounded op80 inline-flex gap-1 items-center
       >
-        <div v-if="def" :class="[def.icon, compact ? 'text-gray-500 dark:text-gray-400' : 'ev-icon-tinted']" text-xs :style="compact ? undefined : { '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }" />
+        <div v-if="def" :class="def.icon" class="ev-icon-tinted" text-xs :style="{ '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }" />
         {{ tag }}
       </span>
     </div>
 
-    <div v-if="theme && !compact" class="ev-watermark" aria-hidden="true">
+    <div v-if="theme" class="ev-watermark" aria-hidden="true">
       <div
         v-for="def in theme.icons.slice(1).reverse()"
         :key="def.icon"
@@ -91,24 +89,8 @@ const taggedChips = computed(() =>
 </template>
 
 <style scoped>
-.event-card-compact h3 {
-  transition: color 150ms;
-}
-
-.event-card-compact:hover h3,
-.event-card-compact:focus-visible h3 {
-  color: var(--ev-color, #0f766e);
-}
-
-html.dark .event-card-compact:hover h3,
-html.dark .event-card-compact:focus-visible h3 {
-  color: var(--ev-color-dark, #2dd4bf);
-}
-
-.compact-description {
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  overflow: hidden;
+/* Desaturate the complete palette without changing content, decoration or layout. */
+.event-card-muted {
+  filter: grayscale(1);
 }
 </style>

--- a/src/components/EventComments.vue
+++ b/src/components/EventComments.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import Giscus from '@giscus/vue'
+import { giscusConfig, repoUrl } from '~/config'
+
+const { eventId } = defineProps<{ eventId: string }>()
+
+/** Keep static HTML independent of the browser-only discussion widget. */
+const mounted = ref(false)
+onMounted(() => mounted.value = true)
+
+const container = shallowRef<HTMLElement>()
+const failed = ref(false)
+const attempt = ref(0)
+
+/** Only the current widget can report failure; an empty discussion is a valid first visit. */
+function handleMessage(message: MessageEvent) {
+  const frame = container.value?.querySelector('giscus-widget')?.shadowRoot?.querySelector('iframe')
+  if (message.origin !== 'https://giscus.app' || !frame?.contentWindow || message.source !== frame.contentWindow)
+    return
+  const error = message.data?.giscus?.error
+  if (typeof error !== 'string' || /Discussion not found|Bad credentials|Invalid state value|State has expired/.test(error))
+    return
+  failed.value = true
+}
+
+/** Remounting gives retries a fresh iframe and releases the old widget's listeners. */
+function retry() {
+  failed.value = false
+  attempt.value++
+}
+
+useEventListener('message', handleMessage)
+watch(() => eventId, retry)
+
+/** Source IDs survive canonical URL variants and changes to an event's title. */
+const term = computed(() => `event:${eventId}`)
+const discussionUrl = computed(() => `${repoUrl}/discussions?discussions_q=${encodeURIComponent(`category:"${giscusConfig.category}" "${term.value}"`)}`)
+</script>
+
+<template>
+  <section id="comments" aria-labelledby="comments-heading" mt-10 pt-8 border-t border-gray-200 scroll-mt-6 dark:border-gray-800>
+    <div flex="~ wrap items-center justify-between gap-3">
+      <h2 id="comments-heading" text-lg font-700 flex="~ items-center gap-2">
+        <div i-carbon-chat text-teal-600 aria-hidden="true" />
+        活动讨论
+      </h2>
+      <a :href="discussionUrl" target="_blank" rel="noopener noreferrer" text-sm text-teal-700 py-2 inline-flex gap-1 items-center dark:text-teal-400 hover:underline>
+        在 GitHub 查看 <div i-carbon-arrow-up-right aria-hidden="true" />
+      </a>
+    </div>
+    <p text-sm text-gray-600 mt-1 dark:text-gray-400>
+      找同行、聊见闻，或分享会后资料。登录 GitHub 即可参与。
+    </p>
+    <div v-show="!failed" ref="container" mt-5>
+      <Giscus
+        v-if="mounted"
+        :key="`${eventId}:${attempt}`"
+        v-bind="giscusConfig"
+        mapping="specific"
+        :term="term"
+        strict="1"
+        reactions-enabled="1"
+        emit-metadata="0"
+        input-position="top"
+        :theme="isDark ? 'dark' : 'light'"
+        lang="zh-CN"
+        loading="lazy"
+      />
+    </div>
+    <div v-if="failed" role="status" mt-5 p-4 rounded-lg bg-gray-50 flex="~ wrap items-center justify-between gap-3" dark:bg-gray-900>
+      <p text-sm text-gray-600 dark:text-gray-400>
+        暂时无法加载评论，可以重试或前往 GitHub 查看。
+      </p>
+      <button type="button" text-sm text-teal-700 px-3 py-2 border border-gray-200 rounded-md dark:text-teal-400 dark:border-gray-700 hover:bg-teal-50 dark:hover:bg-gray-800 @click="retry">
+        重新加载
+      </button>
+    </div>
+    <p v-else text-xs text-gray-500 mt-3 dark:text-gray-400>
+      评论未显示？可通过上方链接前往 GitHub 查看讨论。
+    </p>
+  </section>
+</template>

--- a/src/components/RelatedEvents.vue
+++ b/src/components/RelatedEvents.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import type { NormalizedEvent } from '~/types'
+
+defineProps<{ events: NormalizedEvent[] }>()
+</script>
+
+<template>
+  <section aria-labelledby="related-events-heading" min-w-0>
+    <h2 id="related-events-heading" text-sm tracking-wide font-600 mb-3 op60>
+      相关活动
+    </h2>
+    <ul class="related-list" aria-label="相关活动">
+      <li v-for="event in events" :key="event.id" min-w-0>
+        <EventCard :event="event" h-full />
+      </li>
+    </ul>
+  </section>
+</template>
+
+<style scoped>
+.related-list {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: min(88%, 22rem);
+  gap: 0.75rem;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x proximity;
+  padding: 2px;
+  scrollbar-width: none;
+}
+
+.related-list::-webkit-scrollbar {
+  display: none;
+}
+
+.related-list > li {
+  scroll-snap-align: start;
+}
+
+@media (min-width: 1024px) {
+  .related-list {
+    grid-auto-flow: row;
+    grid-auto-columns: auto;
+    overflow: visible;
+    padding: 2px;
+  }
+}
+</style>

--- a/src/components/RelatedEvents.vue
+++ b/src/components/RelatedEvents.vue
@@ -11,7 +11,7 @@ defineProps<{ events: NormalizedEvent[] }>()
     </h2>
     <ul class="related-list" aria-label="相关活动">
       <li v-for="event in events" :key="event.id" min-w-0>
-        <EventCard :event="event" variant="compact" h-full />
+        <EventCard :event="event" variant="muted" h-full />
       </li>
     </ul>
   </section>

--- a/src/components/RelatedEvents.vue
+++ b/src/components/RelatedEvents.vue
@@ -11,7 +11,7 @@ defineProps<{ events: NormalizedEvent[] }>()
     </h2>
     <ul class="related-list" aria-label="相关活动">
       <li v-for="event in events" :key="event.id" min-w-0>
-        <EventCard :event="event" h-full />
+        <EventCard :event="event" variant="compact" h-full />
       </li>
     </ul>
   </section>

--- a/src/components/RelatedEvents.vue
+++ b/src/components/RelatedEvents.vue
@@ -39,11 +39,16 @@ defineProps<{ events: NormalizedEvent[] }>()
 }
 
 @media (min-width: 1024px) {
+  h2 {
+    line-height: 1.25rem;
+    margin-bottom: 1rem;
+  }
+
   .related-list {
     grid-auto-flow: row;
     grid-auto-columns: auto;
     overflow: visible;
-    padding: 2px;
+    padding: 0;
   }
 }
 </style>

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,3 +17,11 @@ export const siteUrl = 'https://event.rizumu.me'
 export function eventEditUrl(id: string): string {
   return `${repoUrl}/edit/master/data/events/${id}.json`
 }
+
+/** Public giscus identifiers; the GitHub App must have access to this repository. */
+export const giscusConfig = {
+  repo: 'LittleSound/techevent-cn',
+  repoId: 'R_kgDOS7i9yg',
+  category: 'Event comments',
+  categoryId: 'DIC_kwDOS7i9ys4DFcEW',
+} as const

--- a/src/pages/event/[id].vue
+++ b/src/pages/event/[id].vue
@@ -303,6 +303,7 @@ useHead(() => ({
     grid-template-columns: minmax(0, 1fr) 18rem;
     grid-template-rows: min-content 1fr;
     grid-template-areas: 'content related' 'discussion related';
+    column-gap: 3rem;
     align-items: start;
   }
 

--- a/src/pages/event/[id].vue
+++ b/src/pages/event/[id].vue
@@ -72,7 +72,7 @@ useHead(() => ({
       </button>
     </header>
 
-    <div mt-4>
+    <div v-if="!event" mt-4>
       <RouterLink to="/" text-sm op60 inline-flex gap-1 items-center hover:text-teal-600 hover:op100>
         <div i-carbon-arrow-left /> 返回活动列表
       </RouterLink>
@@ -80,6 +80,11 @@ useHead(() => ({
 
     <div v-if="event" class="event-layout" :class="{ 'has-related': related.length }">
       <div class="event-content">
+        <div flex="~ items-center" text-sm leading-5 mt-4>
+          <RouterLink to="/" text-sm op60 inline-flex gap-1 items-center hover:text-teal-600 hover:op100>
+            <div i-carbon-arrow-left /> 返回活动列表
+          </RouterLink>
+        </div>
         <article
           class="card" mt-4 p-6 relative
           :class="theme ? 'ev-themed' : ''" :style="themeStyle"

--- a/src/pages/event/[id].vue
+++ b/src/pages/event/[id].vue
@@ -300,9 +300,9 @@ useHead(() => ({
 
 @media (min-width: 1024px) {
   .event-layout.has-related {
-    grid-template-columns: 18rem minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr) 18rem;
     grid-template-rows: min-content 1fr;
-    grid-template-areas: 'related content' 'related discussion';
+    grid-template-areas: 'content related' 'discussion related';
     align-items: start;
   }
 

--- a/src/pages/event/[id].vue
+++ b/src/pages/event/[id].vue
@@ -234,13 +234,24 @@ useHead(() => ({
           </div>
         </section>
 
-        <aside mt-6 px-4 py-3 rounded-lg bg-gray-50 flex="~ wrap items-center justify-between gap-3" dark:bg-gray-900>
-          <div text-sm flex="~ items-center gap-2">
-            <div i-carbon-edit text-gray-500 shrink-0 aria-hidden="true" />
-            <span>信息有误或缺漏？一起完善这场活动。</span>
+        <section
+          class="mt-10 p-5 border border-teal-200 rounded-xl bg-teal-50/60 dark:border-teal-900 dark:bg-teal-950/25"
+        >
+          <div flex="~ items-start gap-3">
+            <div i-carbon-collaborate text-xl text-teal-600 mt-0.5 shrink-0 />
+            <div>
+              <h2 text-base font-700>
+                发现信息有误或想补充？
+              </h2>
+              <p text-sm mt-1 op70>
+                活动由社区共同维护。你可以直接编辑数据，也可以复制一份完整提示词，让 Agent 帮你调查和整理。
+              </p>
+              <div mt-4>
+                <ContributionMenu intent="edit" :event="event" trigger-style="primary" />
+              </div>
+            </div>
           </div>
-          <ContributionMenu intent="edit" :event="event" label="补充活动信息" />
-        </aside>
+        </section>
       </div>
 
       <RelatedEvents v-if="related.length" :key="event.id" :events="related" class="event-related" />

--- a/src/pages/event/[id].vue
+++ b/src/pages/event/[id].vue
@@ -15,7 +15,7 @@ const eventId = computed(() => String(route.params.id).replace(/\.html$/, ''))
 
 const event = computed(() => allEvents.find(e => e.id === eventId.value))
 
-const related = computed(() => event.value ? relatedEvents(event.value, allEvents) : [])
+const related = computed(() => event.value ? relatedEvents(event.value, allEvents, 2) : [])
 
 const theme = computed(() => event.value && resolveEventTheme(event.value))
 
@@ -51,6 +51,7 @@ useSeoMeta({
 })
 
 useHead(() => ({
+  meta: event.value ? [{ name: 'giscus:backlink', content: eventCanonicalUrl(event.value.id) }] : [],
   link: event.value ? [{ rel: 'canonical', href: eventCanonicalUrl(event.value.id) }] : [],
   script: event.value
     // Escape `<` so event text can never close the script tag early.
@@ -145,6 +146,13 @@ useHead(() => ({
         <EventShareButtons :url="eventCanonicalUrl(event.id)" :title="event.name" />
       </div>
 
+      <div mt-4 flex="~ justify-end">
+        <a href="#comments" text-sm text-teal-700 py-2 inline-flex gap-1.5 items-center dark:text-teal-400 hover:underline>
+          <div i-carbon-chat aria-hidden="true" /> 查看讨论
+          <div i-carbon-arrow-down aria-hidden="true" />
+        </a>
+      </div>
+
       <section v-if="hasLocation(event)" mt-8>
         <h2 text-sm tracking-wide font-600 mb-3 op50>
           地点
@@ -225,24 +233,13 @@ useHead(() => ({
         </div>
       </section>
 
-      <section
-        class="mt-10 p-5 border border-teal-200 rounded-xl bg-teal-50/60 dark:border-teal-900 dark:bg-teal-950/25"
-      >
-        <div flex="~ items-start gap-3">
-          <div i-carbon-collaborate text-xl text-teal-600 mt-0.5 shrink-0 />
-          <div>
-            <h2 text-base font-700>
-              发现信息有误或想补充？
-            </h2>
-            <p text-sm mt-1 op70>
-              活动由社区共同维护。你可以直接编辑数据，也可以复制一份完整提示词，让 Agent 帮你调查和整理。
-            </p>
-            <div mt-4>
-              <ContributionMenu intent="edit" :event="event" trigger-style="primary" />
-            </div>
-          </div>
+      <aside mt-6 px-4 py-3 rounded-lg bg-gray-50 flex="~ wrap items-center justify-between gap-3" dark:bg-gray-900>
+        <div text-sm flex="~ items-center gap-2">
+          <div i-carbon-edit text-gray-500 shrink-0 aria-hidden="true" />
+          <span>信息有误或缺漏？一起完善这场活动。</span>
         </div>
-      </section>
+        <ContributionMenu intent="edit" :event="event" label="补充活动信息" />
+      </aside>
 
       <section v-if="related.length" mt-8>
         <h2 text-sm tracking-wide font-600 mb-3 op50>
@@ -252,6 +249,8 @@ useHead(() => ({
           <EventCard v-for="rel in related" :key="rel.id" :event="rel" />
         </div>
       </section>
+
+      <EventComments :event-id="event.id" />
     </template>
 
     <div v-else mt-16 text-center op60>

--- a/src/pages/event/[id].vue
+++ b/src/pages/event/[id].vue
@@ -15,7 +15,7 @@ const eventId = computed(() => String(route.params.id).replace(/\.html$/, ''))
 
 const event = computed(() => allEvents.find(e => e.id === eventId.value))
 
-const related = computed(() => event.value ? relatedEvents(event.value, allEvents, 2) : [])
+const related = computed(() => event.value ? relatedEvents(event.value, allEvents, 4) : [])
 
 const theme = computed(() => event.value && resolveEventTheme(event.value))
 
@@ -61,7 +61,7 @@ useHead(() => ({
 </script>
 
 <template>
-  <div mx-auto px-4 pb-16 max-w-3xl>
+  <div mx-auto px-4 pb-16 max-w-3xl :class="related.length ? 'lg:max-w-6xl' : ''">
     <header pt-6 flex="~ items-center justify-between gap-3">
       <RouterLink to="/" title="返回首页" class="group">
         <span text-base tracking-tight font-700 transition group-hover:text-teal-600>techevent-cn</span>
@@ -78,180 +78,174 @@ useHead(() => ({
       </RouterLink>
     </div>
 
-    <template v-if="event">
-      <article
-        class="card" mt-4 p-6 relative
-        :class="theme ? 'ev-themed' : ''" :style="themeStyle"
-      >
-        <div flex="~ items-start justify-between gap-3">
-          <h1 text-2xl leading-snug font-700 :class="theme ? 'ev-title-themed' : ''">
-            {{ event.name }}
-          </h1>
-          <span text-xs mt-2 op70 shrink-0>{{ formatLabel[event.format] }}</span>
-        </div>
-
-        <div flex="~ col gap-1.5" text-sm mt-4 op80>
-          <span flex="~ items-center gap-1.5">
-            <div i-carbon-calendar shrink-0 /> {{ formatDateRange(event.start, event.end) }}
-            <span v-if="isPast(event.end)" text-xs px-1.5 rounded bg-gray-100 op70 dark:bg-gray-800>已结束</span>
-          </span>
-          <span flex="~ items-center gap-1.5">
-            <div i-carbon-location shrink-0 />
-            {{ event.city }}<template v-if="event.country !== '中国'"> · {{ event.country }}</template><template v-if="event.venue"> · {{ event.venue }}</template>
-          </span>
-          <span v-if="event.organizer" flex="~ items-center gap-1.5">
-            <div i-carbon-group shrink-0 /> {{ event.organizer }}
-          </span>
-        </div>
-
-        <p v-if="event.description" text-base leading-relaxed mt-4 op80>
-          {{ event.description }}
-        </p>
-
-        <div v-if="event.tags.length" mt-4 flex="~ wrap gap-1.5">
-          <span
-            v-for="{ tag, def } in taggedChips" :key="tag"
-            bg="gray-100 dark:gray-800"
-            text-xs px-2 py-0.5 rounded op80 inline-flex gap-1 items-center
-          >
-            <div v-if="def" :class="def.icon" class="ev-icon-tinted" text-xs :style="{ '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }" />
-            {{ tag }}
-          </span>
-        </div>
-
-        <div v-if="theme" class="ev-watermark" aria-hidden="true">
-          <div
-            v-for="def in theme.icons.slice(1).reverse()"
-            :key="def.icon"
-            class="ev-icon-tinted" :class="[def.icon]"
-            :style="{ 'fontSize': '58px', 'marginRight': '-18px', 'marginBottom': '6px', '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }"
-          />
-          <div :class="theme.primary.icon" :style="{ fontSize: '105px', color: 'var(--ev-c)' }" />
-        </div>
-      </article>
-
-      <div grid="~ cols-2 sm:cols-4 gap-2" mt-3>
-        <a
-          :href="event.url" target="_blank" rel="noopener"
-          text-sm text-white px-3 py-1.5 rounded-md bg-teal-600 inline-flex gap-1 w-full transition items-center justify-center hover:bg-teal-700
+    <div v-if="event" class="event-layout" :class="{ 'has-related': related.length }">
+      <div class="event-content">
+        <article
+          class="card" mt-4 p-6 relative
+          :class="theme ? 'ev-themed' : ''" :style="themeStyle"
         >
-          前往官网 <div i-carbon-arrow-up-right />
-        </a>
-        <a
-          :href="`/ics/${event.id}.ics`"
-          hover="border-teal-600 text-teal-600" download text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 w-full transition items-center justify-center dark:border-gray-700
-        >
-          <div i-carbon-calendar-add /> 加入日历
-        </a>
-        <EventShareButtons :url="eventCanonicalUrl(event.id)" :title="event.name" />
-      </div>
+          <div flex="~ items-start justify-between gap-3">
+            <h1 text-2xl leading-snug font-700 :class="theme ? 'ev-title-themed' : ''">
+              {{ event.name }}
+            </h1>
+            <span text-xs mt-2 op70 shrink-0>{{ formatLabel[event.format] }}</span>
+          </div>
 
-      <div mt-4 flex="~ justify-end">
-        <a href="#comments" text-sm text-teal-700 py-2 inline-flex gap-1.5 items-center dark:text-teal-400 hover:underline>
-          <div i-carbon-chat aria-hidden="true" /> 查看讨论
-          <div i-carbon-arrow-down aria-hidden="true" />
-        </a>
-      </div>
+          <div flex="~ col gap-1.5" text-sm mt-4 op80>
+            <span flex="~ items-center gap-1.5">
+              <div i-carbon-calendar shrink-0 /> {{ formatDateRange(event.start, event.end) }}
+              <span v-if="isPast(event.end)" text-xs px-1.5 rounded bg-gray-100 op70 dark:bg-gray-800>已结束</span>
+            </span>
+            <span flex="~ items-center gap-1.5">
+              <div i-carbon-location shrink-0 />
+              {{ event.city }}<template v-if="event.country !== '中国'"> · {{ event.country }}</template><template v-if="event.venue"> · {{ event.venue }}</template>
+            </span>
+            <span v-if="event.organizer" flex="~ items-center gap-1.5">
+              <div i-carbon-group shrink-0 /> {{ event.organizer }}
+            </span>
+          </div>
 
-      <section v-if="hasLocation(event)" mt-8>
-        <h2 text-sm tracking-wide font-600 mb-3 op50>
-          地点
-        </h2>
-        <template v-if="hasPreciseLocation(event)">
-          <div flex="~ items-center gap-3 justify-between" p-3 border border-gray-200 rounded-lg dark:border-gray-800>
-            <div text-sm op90 flex="~ items-center gap-1.5" min-w-0>
-              <div i-carbon-location op60 shrink-0 />
-              <span truncate>{{ event.venue }} · {{ event.city }}<template v-if="event.country !== '中国'"> · {{ event.country }}</template></span>
-            </div>
-            <button
-              type="button"
-              text-sm text-white px-3 py-1.5 rounded-md bg-teal-600 inline-flex shrink-0 gap-1.5 transition items-center hover:bg-teal-700
-              @click="copyAddress()"
+          <p v-if="event.description" text-base leading-relaxed mt-4 op80>
+            {{ event.description }}
+          </p>
+
+          <div v-if="event.tags.length" mt-4 flex="~ wrap gap-1.5">
+            <span
+              v-for="{ tag, def } in taggedChips" :key="tag"
+              bg="gray-100 dark:gray-800"
+              text-xs px-2 py-0.5 rounded op80 inline-flex gap-1 items-center
             >
-              <div :class="addressCopied ? 'i-carbon-checkmark' : 'i-carbon-copy'" />
-              {{ addressCopied ? '已复制' : '复制地址' }}
-            </button>
+              <div v-if="def" :class="def.icon" class="ev-icon-tinted" text-xs :style="{ '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }" />
+              {{ tag }}
+            </span>
           </div>
 
-          <EventMapEmbed v-if="event.coordinates" :coordinates="event.coordinates" :label="event.venue ?? event.city" mt-3 />
+          <div v-if="theme" class="ev-watermark" aria-hidden="true">
+            <div
+              v-for="def in theme.icons.slice(1).reverse()"
+              :key="def.icon"
+              class="ev-icon-tinted" :class="[def.icon]"
+              :style="{ 'fontSize': '58px', 'marginRight': '-18px', 'marginBottom': '6px', '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }"
+            />
+            <div :class="theme.primary.icon" :style="{ fontSize: '105px', color: 'var(--ev-c)' }" />
+          </div>
+        </article>
 
-          <div text-sm mt-3 op80 flex="~ wrap items-center gap-x-2 gap-y-1.5">
-            <span op60>在地图中打开：</span>
-            <a :href="amapSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
-              <div i-carbon-send-alt /> 高德地图
-            </a>
-            <a :href="baiduMapSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
-              <div i-simple-icons-baidu /> 百度地图
-            </a>
-            <a :href="appleMapsSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
-              <div i-simple-icons-apple /> Apple 地图
-            </a>
-          </div>
-        </template>
-        <div v-else p-3 border border-gray-200 rounded-lg dark:border-gray-800>
-          <div text-sm op90 flex="~ items-center gap-1.5">
-            <div i-carbon-location op60 shrink-0 />
-            {{ event.city }}<template v-if="event.country !== '中国'">
-              · {{ event.country }}
-            </template>
-          </div>
-          <div text-xs mt-1.5 op60 flex="~ items-center gap-1.5">
-            <div i-carbon-information shrink-0 /> 具体活动地点请查看官网信息。
-          </div>
-          <div
-            v-if="missingDetails.includes('venue')"
-            text-sm mt-3 pt-3 border-t border-gray-100 flex="~ wrap items-center gap-x-2 gap-y-1.5"
-            dark:border-gray-800
-          >
-            <span op65>知道具体场馆？欢迎帮大家补上。</span>
-            <ContributionMenu intent="edit" :event="event" label="补充地点" />
-          </div>
-        </div>
-      </section>
-
-      <section mt-8>
-        <h2 text-sm tracking-wide font-600 mb-3 op50>
-          相关链接
-        </h2>
-        <div v-if="resolvedLinks.length" flex="~ wrap gap-2">
+        <div grid="~ cols-2 sm:cols-4 gap-2" mt-3>
           <a
-            v-for="link in resolvedLinks" :key="link.url"
-            :href="link.url" target="_blank" rel="noopener"
-            hover="border-teal-600 text-teal-600" text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 transition items-center dark:border-gray-700
+            :href="event.url" target="_blank" rel="noopener"
+            text-sm text-white px-3 py-1.5 rounded-md bg-teal-600 inline-flex gap-1 w-full transition items-center justify-center hover:bg-teal-700
           >
-            <div :class="link.icon" /> {{ link.label }}
+            前往官网 <div i-carbon-arrow-up-right />
+          </a>
+          <a
+            :href="`/ics/${event.id}.ics`"
+            hover="border-teal-600 text-teal-600" download text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 w-full transition items-center justify-center dark:border-gray-700
+          >
+            <div i-carbon-calendar-add /> 加入日历
+          </a>
+          <EventShareButtons :url="eventCanonicalUrl(event.id)" :title="event.name" />
+        </div>
+
+        <div mt-4 flex="~ justify-end">
+          <a href="#comments" text-sm text-teal-700 py-2 inline-flex gap-1.5 items-center dark:text-teal-400 hover:underline>
+            <div i-carbon-chat aria-hidden="true" /> 查看讨论
+            <div i-carbon-arrow-down aria-hidden="true" />
           </a>
         </div>
-        <div
-          v-else
-          flex="~ wrap items-center gap-x-2 gap-y-1.5"
-          text-sm p-3 border border-gray-300 rounded-lg border-dashed dark:border-gray-700
-        >
-          <div i-carbon-link op45 shrink-0 />
-          <span op65>暂时还没有收录报名、议程或官方社媒等相关链接。</span>
-          <ContributionMenu intent="edit" :event="event" label="补充相关链接" />
-        </div>
-      </section>
 
-      <aside mt-6 px-4 py-3 rounded-lg bg-gray-50 flex="~ wrap items-center justify-between gap-3" dark:bg-gray-900>
-        <div text-sm flex="~ items-center gap-2">
-          <div i-carbon-edit text-gray-500 shrink-0 aria-hidden="true" />
-          <span>信息有误或缺漏？一起完善这场活动。</span>
-        </div>
-        <ContributionMenu intent="edit" :event="event" label="补充活动信息" />
-      </aside>
+        <section v-if="hasLocation(event)" mt-8>
+          <h2 text-sm tracking-wide font-600 mb-3 op50>
+            地点
+          </h2>
+          <template v-if="hasPreciseLocation(event)">
+            <div flex="~ items-center gap-3 justify-between" p-3 border border-gray-200 rounded-lg dark:border-gray-800>
+              <div text-sm op90 flex="~ items-center gap-1.5" min-w-0>
+                <div i-carbon-location op60 shrink-0 />
+                <span truncate>{{ event.venue }} · {{ event.city }}<template v-if="event.country !== '中国'"> · {{ event.country }}</template></span>
+              </div>
+              <button
+                type="button"
+                text-sm text-white px-3 py-1.5 rounded-md bg-teal-600 inline-flex shrink-0 gap-1.5 transition items-center hover:bg-teal-700
+                @click="copyAddress()"
+              >
+                <div :class="addressCopied ? 'i-carbon-checkmark' : 'i-carbon-copy'" />
+                {{ addressCopied ? '已复制' : '复制地址' }}
+              </button>
+            </div>
 
-      <section v-if="related.length" mt-8>
-        <h2 text-sm tracking-wide font-600 mb-3 op50>
-          相关活动
-        </h2>
-        <div grid="~ cols-1 sm:cols-2 gap-3">
-          <EventCard v-for="rel in related" :key="rel.id" :event="rel" />
-        </div>
-      </section>
+            <EventMapEmbed v-if="event.coordinates" :coordinates="event.coordinates" :label="event.venue ?? event.city" mt-3 />
 
-      <EventComments :event-id="event.id" />
-    </template>
+            <div text-sm mt-3 op80 flex="~ wrap items-center gap-x-2 gap-y-1.5">
+              <span op60>在地图中打开：</span>
+              <a :href="amapSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
+                <div i-carbon-send-alt /> 高德地图
+              </a>
+              <a :href="baiduMapSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
+                <div i-simple-icons-baidu /> 百度地图
+              </a>
+              <a :href="appleMapsSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
+                <div i-simple-icons-apple /> Apple 地图
+              </a>
+            </div>
+          </template>
+          <div v-else p-3 border border-gray-200 rounded-lg dark:border-gray-800>
+            <div text-sm op90 flex="~ items-center gap-1.5">
+              <div i-carbon-location op60 shrink-0 />
+              {{ event.city }}<template v-if="event.country !== '中国'">
+                · {{ event.country }}
+              </template>
+            </div>
+            <div text-xs mt-1.5 op60 flex="~ items-center gap-1.5">
+              <div i-carbon-information shrink-0 /> 具体活动地点请查看官网信息。
+            </div>
+            <div
+              v-if="missingDetails.includes('venue')"
+              text-sm mt-3 pt-3 border-t border-gray-100 flex="~ wrap items-center gap-x-2 gap-y-1.5"
+              dark:border-gray-800
+            >
+              <span op65>知道具体场馆？欢迎帮大家补上。</span>
+              <ContributionMenu intent="edit" :event="event" label="补充地点" />
+            </div>
+          </div>
+        </section>
+
+        <section mt-8>
+          <h2 text-sm tracking-wide font-600 mb-3 op50>
+            相关链接
+          </h2>
+          <div v-if="resolvedLinks.length" flex="~ wrap gap-2">
+            <a
+              v-for="link in resolvedLinks" :key="link.url"
+              :href="link.url" target="_blank" rel="noopener"
+              hover="border-teal-600 text-teal-600" text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 transition items-center dark:border-gray-700
+            >
+              <div :class="link.icon" /> {{ link.label }}
+            </a>
+          </div>
+          <div
+            v-else
+            flex="~ wrap items-center gap-x-2 gap-y-1.5"
+            text-sm p-3 border border-gray-300 rounded-lg border-dashed dark:border-gray-700
+          >
+            <div i-carbon-link op45 shrink-0 />
+            <span op65>暂时还没有收录报名、议程或官方社媒等相关链接。</span>
+            <ContributionMenu intent="edit" :event="event" label="补充相关链接" />
+          </div>
+        </section>
+
+        <aside mt-6 px-4 py-3 rounded-lg bg-gray-50 flex="~ wrap items-center justify-between gap-3" dark:bg-gray-900>
+          <div text-sm flex="~ items-center gap-2">
+            <div i-carbon-edit text-gray-500 shrink-0 aria-hidden="true" />
+            <span>信息有误或缺漏？一起完善这场活动。</span>
+          </div>
+          <ContributionMenu intent="edit" :event="event" label="补充活动信息" />
+        </aside>
+      </div>
+
+      <RelatedEvents v-if="related.length" :key="event.id" :events="related" class="event-related" />
+      <EventComments :event-id="event.id" class="event-discussion" />
+    </div>
 
     <div v-else mt-16 text-center op60>
       <div i-carbon-help text-4xl mx-auto mb-3 op50 />
@@ -265,3 +259,44 @@ useHead(() => ({
     </div>
   </div>
 </template>
+
+<style scoped>
+.event-layout {
+  display: grid;
+  grid-template-areas: 'content' 'discussion';
+  gap: 2rem;
+}
+
+.event-layout.has-related {
+  grid-template-areas: 'content' 'related' 'discussion';
+}
+
+.event-content {
+  grid-area: content;
+  min-width: 0;
+}
+
+.event-related {
+  grid-area: related;
+  min-width: 0;
+}
+
+.event-discussion {
+  grid-area: discussion;
+  min-width: 0;
+  margin-top: 0;
+}
+
+@media (min-width: 1024px) {
+  .event-layout.has-related {
+    grid-template-columns: 18rem minmax(0, 1fr);
+    grid-template-rows: min-content 1fr;
+    grid-template-areas: 'related content' 'related discussion';
+    align-items: start;
+  }
+
+  .event-related {
+    margin-top: 1rem;
+  }
+}
+</style>

--- a/test/event-card.test.ts
+++ b/test/event-card.test.ts
@@ -1,7 +1,10 @@
 import { mount } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { createMemoryHistory, createRouter } from 'vue-router'
+import { parse } from 'vue/compiler-sfc'
 import EventCard from '~/components/EventCard.vue'
+import eventCardSource from '~/components/EventCard.vue?raw'
+import eventThemeCss from '~/styles/event-theme.css?raw'
 import { normalizeEvent } from '~/utils/events'
 
 const event = normalizeEvent({
@@ -16,6 +19,29 @@ const event = normalizeEvent({
 }, 'vue-community')
 
 describe('eventCard', () => {
+  it('uses the neutral card border at rest in both color schemes', () => {
+    const style = document.createElement('style')
+    style.textContent = (eventThemeCss + parse(eventCardSource).descriptor.styles.map(block => block.content).join('\n'))
+      .replaceAll('var(--colors-gray-200)', '#e5e7eb')
+      .replaceAll('var(--colors-gray-800)', '#1f2937')
+    const card = document.createElement('a')
+    card.className = 'card ev-themed event-card-muted'
+    document.head.append(style)
+    document.body.append(card)
+    const originalClass = document.documentElement.className
+    try {
+      document.documentElement.classList.remove('dark')
+      expect(getComputedStyle(card).borderTopColor).toBe('rgb(229, 231, 235)')
+      document.documentElement.classList.add('dark')
+      expect(getComputedStyle(card).borderTopColor).toBe('rgb(31, 41, 55)')
+    }
+    finally {
+      card.remove()
+      style.remove()
+      document.documentElement.className = originalClass
+    }
+  })
+
   it('preserves all content and decorative icons when only the palette is muted', async () => {
     const router = createRouter({ history: createMemoryHistory(), routes: [{ path: '/event/:id', component: { template: '<div />' } }] })
     await router.push('/event/current')

--- a/test/event-card.test.ts
+++ b/test/event-card.test.ts
@@ -26,6 +26,8 @@ describe('eventCard', () => {
     expect(wrapper.text()).toContain('opensource')
 
     const originalContent = wrapper.text()
+    const originalPalette = wrapper.attributes('style')
+    const originalIconPalette = wrapper.findAll('.ev-icon-tinted').map(icon => icon.attributes('style')?.split(';').map(part => part.trim()).sort())
     const originalIcons = wrapper.findAll('.ev-watermark > div').map(icon => icon.classes())
     const originalTitle = wrapper.get('h3').attributes()
     const originalDescription = wrapper.get('p').attributes()
@@ -33,6 +35,8 @@ describe('eventCard', () => {
     expect(wrapper.classes()).toContain('event-card-muted')
     expect(wrapper.classes()).toContain('ev-themed')
     expect(wrapper.text()).toBe(originalContent)
+    expect(wrapper.attributes('style')).toBe(originalPalette)
+    expect(wrapper.findAll('.ev-icon-tinted').map(icon => icon.attributes('style')?.split(';').map(part => part.trim()).sort())).toEqual(originalIconPalette)
     expect(wrapper.findAll('.ev-watermark > div').map(icon => icon.classes())).toEqual(originalIcons)
     expect(wrapper.get('h3').attributes()).toEqual(originalTitle)
     expect(wrapper.get('p').attributes()).toEqual(originalDescription)

--- a/test/event-card.test.ts
+++ b/test/event-card.test.ts
@@ -1,0 +1,46 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import EventCard from '~/components/EventCard.vue'
+import { normalizeEvent } from '~/utils/events'
+
+const event = normalizeEvent({
+  id: 'vue-community',
+  name: 'Vue community meetup',
+  startDate: '2026-10-24',
+  city: '上海',
+  organizer: 'Community organizers',
+  description: 'A community meetup with talks and workshops.',
+  tags: ['vue', 'ai', 'opensource'],
+  url: 'https://example.com',
+}, 'vue-community')
+
+describe('eventCard', () => {
+  it('preserves the full default card and reduces secondary content only in compact mode', async () => {
+    const router = createRouter({ history: createMemoryHistory(), routes: [{ path: '/event/:id', component: { template: '<div />' } }] })
+    await router.push('/event/current')
+    const wrapper = mount(EventCard, { props: { event }, global: { plugins: [router] } })
+    expect(wrapper.classes()).toContain('ev-themed')
+    expect(wrapper.find('.ev-watermark').exists()).toBe(true)
+    expect(wrapper.text()).toContain(event.organizer)
+    expect(wrapper.text()).toContain('opensource')
+
+    await wrapper.setProps({ variant: 'compact' })
+    expect(wrapper.classes()).not.toContain('ev-themed')
+    expect(wrapper.find('.ev-watermark').exists()).toBe(false)
+    expect(wrapper.find('.ev-icon-tinted').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain(event.organizer)
+    expect(wrapper.text()).not.toContain('opensource')
+    expect(wrapper.text()).toContain('vue')
+    expect(wrapper.text()).toContain('ai')
+    expect(wrapper.text()).toContain(event.city)
+    expect(wrapper.get('p').text()).toBe(event.description)
+    expect(wrapper.get('h3').text()).toBe(event.name)
+    expect(wrapper.attributes('href')).toBe(`/event/${event.id}`)
+
+    await wrapper.setProps({ variant: 'default' })
+    expect(wrapper.find('.ev-watermark').exists()).toBe(true)
+    expect(wrapper.text()).toContain('opensource')
+    wrapper.unmount()
+  })
+})

--- a/test/event-card.test.ts
+++ b/test/event-card.test.ts
@@ -16,7 +16,7 @@ const event = normalizeEvent({
 }, 'vue-community')
 
 describe('eventCard', () => {
-  it('preserves the full default card and reduces secondary content only in compact mode', async () => {
+  it('preserves all content and decorative icons when only the palette is muted', async () => {
     const router = createRouter({ history: createMemoryHistory(), routes: [{ path: '/event/:id', component: { template: '<div />' } }] })
     await router.push('/event/current')
     const wrapper = mount(EventCard, { props: { event }, global: { plugins: [router] } })
@@ -25,17 +25,20 @@ describe('eventCard', () => {
     expect(wrapper.text()).toContain(event.organizer)
     expect(wrapper.text()).toContain('opensource')
 
-    await wrapper.setProps({ variant: 'compact' })
-    expect(wrapper.classes()).not.toContain('ev-themed')
-    expect(wrapper.find('.ev-watermark').exists()).toBe(false)
-    expect(wrapper.find('.ev-icon-tinted').exists()).toBe(false)
-    expect(wrapper.text()).not.toContain(event.organizer)
-    expect(wrapper.text()).not.toContain('opensource')
-    expect(wrapper.text()).toContain('vue')
-    expect(wrapper.text()).toContain('ai')
-    expect(wrapper.text()).toContain(event.city)
-    expect(wrapper.get('p').text()).toBe(event.description)
-    expect(wrapper.get('h3').text()).toBe(event.name)
+    const originalContent = wrapper.text()
+    const originalIcons = wrapper.findAll('.ev-watermark > div').map(icon => icon.classes())
+    const originalTitle = wrapper.get('h3').attributes()
+    const originalDescription = wrapper.get('p').attributes()
+    await wrapper.setProps({ variant: 'muted' })
+    expect(wrapper.classes()).toContain('event-card-muted')
+    expect(wrapper.classes()).toContain('ev-themed')
+    expect(wrapper.text()).toBe(originalContent)
+    expect(wrapper.findAll('.ev-watermark > div').map(icon => icon.classes())).toEqual(originalIcons)
+    expect(wrapper.get('h3').attributes()).toEqual(originalTitle)
+    expect(wrapper.get('p').attributes()).toEqual(originalDescription)
+    expect(wrapper.find('.ev-watermark').exists()).toBe(true)
+    expect(wrapper.text()).toContain(event.organizer)
+    expect(wrapper.text()).toContain('opensource')
     expect(wrapper.attributes('href')).toBe(`/event/${event.id}`)
 
     await wrapper.setProps({ variant: 'default' })

--- a/test/event-comments.test.ts
+++ b/test/event-comments.test.ts
@@ -1,0 +1,78 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createSSRApp, defineComponent, h, nextTick, ref } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import EventComments from '~/components/EventComments.vue'
+import { isDark } from '~/composables/dark'
+
+vi.mock('~/composables/dark', () => ({ isDark: ref(false) }))
+
+vi.mock('@giscus/vue', () => ({
+  default: defineComponent({
+    name: 'Giscus',
+    inheritAttrs: false,
+    setup: (_, { attrs }) => () => h('giscus-widget', { ...attrs, 'data-testid': 'giscus' }),
+  }),
+}))
+
+afterEach(() => {
+  isDark.value = false
+})
+
+describe('eventComments', () => {
+  it('keeps the discussion link in static HTML without rendering the browser widget', async () => {
+    const html = await renderToString(createSSRApp(EventComments, { eventId: 'vueconf-2026' }))
+    expect(html).toContain('活动讨论')
+    expect(html).toContain('github.com/LittleSound/techevent-cn/discussions')
+    expect(html).not.toContain('data-testid="giscus"')
+  })
+
+  it('offers a retry for service errors but ignores unrelated messages and empty discussions', async () => {
+    const wrapper = mount(EventComments, { props: { eventId: 'vueconf-2026' }, attachTo: document.body })
+    await flushPromises()
+    const element = wrapper.get('[data-testid="giscus"]').element
+    const iframe = document.createElement('iframe')
+    Object.defineProperty(iframe, 'contentWindow', { value: window })
+    element.attachShadow({ mode: 'open' }).appendChild(iframe)
+    const send = (error: string, origin = 'https://giscus.app', source = iframe.contentWindow) => window.dispatchEvent(new MessageEvent('message', {
+      origin,
+      source,
+      data: { giscus: { error } },
+    }))
+    send('Service unavailable', 'https://example.com')
+    send('Service unavailable', 'https://giscus.app', null)
+    send('Discussion not found')
+    await nextTick()
+    expect(wrapper.find('[role="status"]').exists()).toBe(false)
+    send('Service unavailable')
+    await nextTick()
+    expect(wrapper.get('[role="status"]').text()).toContain('暂时无法加载评论')
+    const previous = element
+    await wrapper.get('button').trigger('click')
+    expect(wrapper.find('[role="status"]').exists()).toBe(false)
+    expect(wrapper.get('[data-testid="giscus"]').element).not.toBe(previous)
+    wrapper.unmount()
+  })
+
+  it('uses stable event keys, lazy loading and the site theme', async () => {
+    const wrapper = mount(EventComments, { props: { eventId: 'vueconf-2026' } })
+    await flushPromises()
+    const widget = () => wrapper.get('[data-testid="giscus"]')
+    expect(widget().attributes()).toMatchObject({
+      'mapping': 'specific',
+      'term': 'event:vueconf-2026',
+      'strict': '1',
+      'loading': 'lazy',
+      'lang': 'zh-CN',
+      'theme': 'light',
+      'input-position': 'top',
+    })
+    isDark.value = true
+    await nextTick()
+    expect(widget().attributes('theme')).toBe('dark')
+    await wrapper.setProps({ eventId: 'adventurex-2026' })
+    expect(widget().attributes('term')).toBe('event:adventurex-2026')
+    expect(decodeURIComponent(wrapper.get('a').attributes('href'))).toContain('event:adventurex-2026')
+    wrapper.unmount()
+  })
+})

--- a/test/related-events-component.test.ts
+++ b/test/related-events-component.test.ts
@@ -1,0 +1,31 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import RelatedEvents from '~/components/RelatedEvents.vue'
+import { normalizeEvent } from '~/utils/events'
+
+const events = Array.from({ length: 4 }, (_, index) => normalizeEvent({
+  id: `event-${index}`,
+  name: `Community event ${index}`,
+  startDate: '2026-10-24',
+  city: '上海',
+  url: 'https://example.com',
+}, `event-${index}`))
+
+describe('relatedEvents', () => {
+  it('keeps all four recommendations as individually navigable links when events change', async () => {
+    const router = createRouter({ history: createMemoryHistory(), routes: [{ path: '/event/:id', component: { template: '<div />' } }] })
+    await router.push('/event/current')
+    await router.isReady()
+    const wrapper = mount(RelatedEvents, { props: { events }, global: { plugins: [router] } })
+    expect(wrapper.get('section').attributes('aria-labelledby')).toBe(wrapper.get('h2').attributes('id'))
+    expect(wrapper.findAll('li')).toHaveLength(4)
+    expect(wrapper.findAll('a').map(link => link.attributes('href'))).toEqual(events.map(event => `/event/${event.id}`))
+    await wrapper.findAll('a')[3]!.trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.params.id).toBe('event-3')
+    await wrapper.setProps({ events: events.slice(1) })
+    expect(wrapper.findAll('a').map(link => link.attributes('href'))).toEqual(events.slice(1).map(event => `/event/${event.id}`))
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
Event detail pages now include giscus discussions below the main content, with a direct jump link near the primary actions. The existing contribution callout retains its original styling, wording and primary action.

Related events use four recommendations: a vertical right sidebar on desktop (1024px and up), and a single horizontal carousel before the comments on smaller screens. Mobile cards occupy about 88% of the available width, revealing the next card; native scrolling and proximity snapping keep browsing lightweight. Changing events resets the carousel. The desktop columns have a 48px gutter. The back link aligns with the related-events heading, and the main event card aligns with the first recommendation card. The sidebar cannot stretch the gap between the main content and comments.

The official Vue integration loads the iframe lazily, follows the site's theme, and uses strict `event:<id>` mapping so title changes and `.html` URL variants share one discussion. Canonical backlinks point to production. Service errors show a Chinese retry state with a persistent GitHub fallback; only messages from the current giscus iframe are accepted.

Validation:
- Chrome measured matching desktop heading tops (80px) and card tops (116px); lint, typecheck and the related-events test pass after the alignment change.
- Added a light/dark resting-border regression test; lint, typecheck and the card/recommendation component tests pass after the border fix.
- Chrome verified light/dark resting and hover states, keyboard focus, readable foreground colors and unchanged background/glow.
- `pnpm run lint --fix`, `pnpm run typecheck`, and production SSG build passed.
- All 66 tests passed, including default/muted card behavior and recommendation navigation.
- Chrome previously verified desktop and mobile layouts, 320px and 390px layouts, actual horizontal scrolling, next-card visibility, navigation reset and no page-level horizontal overflow.
- The live giscus widget displays its editor and GitHub sign-in entry; theme switching and failure retry were checked. No real event comments were posted; signed-in posting was not exercised.

Related recommendations opt into `EventCard` muted mode: resting titles and icons use the readable body text color; hover and keyboard focus restore their original theme colors. Card backgrounds and glow keep their original styling, without a card-wide grayscale filter. Resting borders use the standard neutral gray card border in light and dark modes; hover and keyboard focus retain the themed border. Watermarks, typography, organizer, full descriptions and all tags retain their original layout and visibility. Default cards elsewhere keep their original colors. The existing contribution callout is unchanged.

Configuration:
Discussions is enabled, the restricted **Event comments** category exists, and the user installed giscus for **LittleSound/techevent-cn only**. Public IDs are configured; no secret is exposed to the client.





