### PR TITLE
feat: redesign event details around planning and discussion

### DIFF
--- a/src/components/ContributionMenu.vue
+++ b/src/components/ContributionMenu.vue
@@ -64,7 +64,7 @@ const copyDescription = computed(() =>
 const triggerClass = computed(() => ({
   icon: 'icon-btn',
   link: 'text-teal-600 inline-flex gap-1 items-center hover:underline',
-  primary: 'text-sm text-white px-3 py-2 rounded-md bg-teal-600 inline-flex gap-1.5 transition items-center justify-center hover:bg-teal-700',
+  primary: 'action-button',
   secondary: 'text-sm px-3 py-2 border border-gray-200 rounded-md inline-flex gap-1.5 transition items-center justify-center hover:text-teal-600 hover:border-teal-600 dark:border-gray-700',
 })[triggerStyle])
 

--- a/src/components/EventMarkdownButton.vue
+++ b/src/components/EventMarkdownButton.vue
@@ -2,7 +2,7 @@
 import type { NormalizedEvent } from '~/types'
 import { eventMarkdown } from '~/utils/eventMarkdown'
 
-const { event } = defineProps<{ event: NormalizedEvent }>()
+const { event, variant = 'default' } = defineProps<{ event: NormalizedEvent, variant?: 'default' | 'primary' }>()
 const copied = ref(false)
 const failed = ref(false)
 const { start: resetCopied } = useTimeoutFn(() => copied.value = false, 1500, { immediate: false })
@@ -25,6 +25,7 @@ async function copyMarkdown() {
 <template>
   <button
     type="button"
+    :class="{ 'markdown-primary': variant === 'primary' }"
     title="复制完整活动信息，方便交给 Agent 规划行程"
     hover="border-teal-600 text-teal-600" text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 w-full transition items-center justify-center dark:border-gray-700
     @click="copyMarkdown"
@@ -33,3 +34,18 @@ async function copyMarkdown() {
     <span aria-live="polite">{{ failed ? '复制失败，请重试' : copied ? '已复制 Markdown' : '复制 Markdown' }}</span>
   </button>
 </template>
+
+<style scoped>
+.markdown-primary {
+  padding: 0.85rem 1rem;
+  color: white;
+  background: var(--detail-action, #0d7664);
+  border-color: var(--detail-action, #0d7664);
+}
+
+.markdown-primary:hover {
+  color: white;
+  background: var(--detail-action-hover, #115e52);
+  border-color: var(--detail-action-hover, #115e52);
+}
+</style>

--- a/src/components/EventMarkdownButton.vue
+++ b/src/components/EventMarkdownButton.vue
@@ -25,27 +25,11 @@ async function copyMarkdown() {
 <template>
   <button
     type="button"
-    :class="{ 'markdown-primary': variant === 'primary' }"
+    :class="variant === 'primary' ? 'action-button w-full' : 'text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 w-full transition items-center justify-center dark:border-gray-700 hover:border-teal-600 hover:text-teal-600'"
     title="复制完整活动信息，方便交给 Agent 规划行程"
-    hover="border-teal-600 text-teal-600" text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 w-full transition items-center justify-center dark:border-gray-700
     @click="copyMarkdown"
   >
     <div :class="copied && !failed ? 'i-carbon-checkmark' : 'i-carbon-copy'" aria-hidden="true" />
     <span aria-live="polite">{{ failed ? '复制失败，请重试' : copied ? '已复制 Markdown' : '复制 Markdown' }}</span>
   </button>
 </template>
-
-<style scoped>
-.markdown-primary {
-  padding: 0.85rem 1rem;
-  color: white;
-  background: var(--detail-action, #0d7664);
-  border-color: var(--detail-action, #0d7664);
-}
-
-.markdown-primary:hover {
-  color: white;
-  background: var(--detail-action-hover, #115e52);
-  border-color: var(--detail-action-hover, #115e52);
-}
-</style>

--- a/src/pages/event/[id].vue
+++ b/src/pages/event/[id].vue
@@ -9,6 +9,7 @@ import { relatedEvents } from '~/utils/related'
 import { buildEventJsonLd, eventCanonicalUrl, eventOgImageUrl } from '~/utils/seo'
 
 const route = useRoute('/event/[id]')
+const router = useRouter()
 
 /** Prerendered files live at /event/<id>.html, so direct visits may carry the extension in the param; strip it so both URL forms resolve to the same event. */
 const eventId = computed(() => String(route.params.id).replace(/\.html$/, ''))
@@ -58,212 +59,277 @@ useHead(() => ({
     ? [{ type: 'application/ld+json', innerHTML: JSON.stringify(buildEventJsonLd(event.value)).replace(/</g, '\\u003C') }]
     : [],
 }))
+
+const past = computed(() => event.value ? isPast(event.value.end) : false)
+const activeTab = ref<'details' | 'discussion'>('details')
+
+/** Hash links open discussions after hydration, while ordinary event navigation resets the tab. */
+function syncTab() {
+  activeTab.value = route.hash === '#comments' ? 'discussion' : 'details'
+}
+onMounted(syncTab)
+watch(() => [eventId.value, route.hash], syncTab)
+
+/** Keep a shareable tab URL without moving the viewport on each tab switch. */
+async function selectTab(tab: 'details' | 'discussion', scroll = false) {
+  activeTab.value = tab
+  await router.replace({ hash: tab === 'discussion' ? '#comments' : '#details' })
+  if (scroll) {
+    await nextTick()
+    document.getElementById('detail-tabs')?.scrollIntoView({ block: 'start' })
+  }
+}
+
+/** Arrow keys and Home/End move focus and selection together, following the tabs pattern. */
+async function navigateTabs(key: string) {
+  const tab = key === 'Home' ? 'details' : key === 'End' ? 'discussion' : activeTab.value === 'details' ? 'discussion' : 'details'
+  await selectTab(tab)
+  document.getElementById(`${tab}-tab`)?.focus()
+}
 </script>
 
 <template>
-  <div mx-auto px-4 pb-16 max-w-3xl :class="related.length ? 'lg:max-w-6xl' : ''">
-    <header pt-6 flex="~ items-center justify-between gap-3">
-      <RouterLink to="/" title="返回首页" class="group">
-        <span text-base tracking-tight font-700 transition group-hover:text-teal-600>techevent-cn</span>
-        <span text-xs op60 block>中国（及周边）科技活动日历</span>
+  <div class="detail-page">
+    <header class="site-header">
+      <RouterLink to="/" title="返回首页">
+        <span class="site-name">techevent-cn</span>
+        <span class="site-caption">中国（及周边）科技活动日历</span>
       </RouterLink>
-      <button class="icon-btn" title="切换暗色模式" @click="toggleDark()">
+      <button class="icon-btn" title="切换暗色模式" aria-label="切换暗色模式" @click="toggleDark()">
         <div i-carbon-sun dark:i-carbon-moon />
       </button>
     </header>
+    <RouterLink to="/" class="back-link">
+      <div i-carbon-arrow-left aria-hidden="true" /> 返回活动列表
+    </RouterLink>
 
-    <div v-if="!event" mt-4>
-      <RouterLink to="/" text-sm op60 inline-flex gap-1 items-center hover:text-teal-600 hover:op100>
-        <div i-carbon-arrow-left /> 返回活动列表
-      </RouterLink>
-    </div>
-
-    <div v-if="event" class="event-layout" :class="{ 'has-related': related.length }">
-      <div class="event-content">
-        <div flex="~ items-center" text-sm leading-5 mt-4>
-          <RouterLink to="/" text-sm op60 inline-flex gap-1 items-center hover:text-teal-600 hover:op100>
-            <div i-carbon-arrow-left /> 返回活动列表
-          </RouterLink>
+    <template v-if="event">
+      <article class="event-hero card" :class="theme ? 'ev-themed' : ''" :style="themeStyle">
+        <div class="hero-meta">
+          <span><div :class="event.format === 'online' ? 'i-carbon-video' : 'i-carbon-location'" aria-hidden="true" />{{ event.format === 'online' ? '线上活动' : [event.country, event.city].join(' · ') }}</span>
+          <span class="format-badge">{{ formatLabel[event.format] }}</span>
+          <span v-if="past" class="past-badge">已结束</span>
         </div>
-        <article
-          class="card" mt-4 p-6 relative
-          :class="theme ? 'ev-themed' : ''" :style="themeStyle"
-        >
-          <div flex="~ items-start justify-between gap-3">
-            <h1 text-2xl leading-snug font-700 :class="theme ? 'ev-title-themed' : ''">
-              {{ event.name }}
-            </h1>
-            <span text-xs mt-2 op70 shrink-0>{{ formatLabel[event.format] }}</span>
-          </div>
-
-          <div flex="~ col gap-1.5" text-sm mt-4 op80>
-            <span flex="~ items-center gap-1.5">
-              <div i-carbon-calendar shrink-0 /> {{ formatDateRange(event.start, event.end) }}
-              <span v-if="isPast(event.end)" text-xs px-1.5 rounded bg-gray-100 op70 dark:bg-gray-800>已结束</span>
-            </span>
-            <span flex="~ items-center gap-1.5">
-              <div i-carbon-location shrink-0 />
-              {{ event.city }}<template v-if="event.country !== '中国'"> · {{ event.country }}</template><template v-if="event.venue"> · {{ event.venue }}</template>
-            </span>
-            <span v-if="event.organizer" flex="~ items-center gap-1.5">
-              <div i-carbon-group shrink-0 /> {{ event.organizer }}
-            </span>
-          </div>
-
-          <p v-if="event.description" text-base leading-relaxed mt-4 op80>
-            {{ event.description }}
-          </p>
-
-          <div v-if="event.tags.length" mt-4 flex="~ wrap gap-1.5">
-            <span
-              v-for="{ tag, def } in taggedChips" :key="tag"
-              bg="gray-100 dark:gray-800"
-              text-xs px-2 py-0.5 rounded op80 inline-flex gap-1 items-center
-            >
-              <div v-if="def" :class="def.icon" class="ev-icon-tinted" text-xs :style="{ '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }" />
-              {{ tag }}
-            </span>
-          </div>
-
-          <div v-if="theme" class="ev-watermark" aria-hidden="true">
-            <div
-              v-for="def in theme.icons.slice(1).reverse()"
-              :key="def.icon"
-              class="ev-icon-tinted" :class="[def.icon]"
-              :style="{ 'fontSize': '58px', 'marginRight': '-18px', 'marginBottom': '6px', '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }"
-            />
-            <div :class="theme.primary.icon" :style="{ fontSize: '105px', color: 'var(--ev-c)' }" />
-          </div>
-        </article>
-
-        <div grid="~ cols-2 sm:cols-4 gap-2" mt-3>
-          <a
-            :href="event.url" target="_blank" rel="noopener"
-            text-sm text-white px-3 py-1.5 rounded-md bg-teal-600 inline-flex gap-1 w-full transition items-center justify-center hover:bg-teal-700
+        <h1 :class="theme ? 'ev-title-themed' : ''">
+          {{ event.name }}
+        </h1>
+        <div v-if="event.tags.length" mt-4 flex="~ wrap gap-1.5">
+          <span
+            v-for="{ tag, def } in taggedChips" :key="tag"
+            bg="gray-100 dark:gray-800"
+            text-xs px-2 py-0.5 rounded op80 inline-flex gap-1 items-center
           >
-            前往官网 <div i-carbon-arrow-up-right />
-          </a>
-          <a
-            :href="`/ics/${event.id}.ics`"
-            hover="border-teal-600 text-teal-600" download text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 w-full transition items-center justify-center dark:border-gray-700
-          >
-            <div i-carbon-calendar-add /> 加入日历
-          </a>
-          <EventShareButtons :url="eventCanonicalUrl(event.id)" :title="event.name" />
-          <EventMarkdownButton :event="event" />
+            <div v-if="def" :class="def.icon" class="ev-icon-tinted" text-xs :style="{ '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }" />
+            {{ tag }}
+          </span>
         </div>
 
-        <div mt-4 flex="~ justify-end">
-          <a href="#comments" text-sm text-teal-700 py-2 inline-flex gap-1.5 items-center dark:text-teal-400 hover:underline>
-            <div i-carbon-chat aria-hidden="true" /> 查看讨论
-            <div i-carbon-arrow-down aria-hidden="true" />
-          </a>
-        </div>
-
-        <section v-if="hasLocation(event)" mt-8>
-          <h2 text-sm tracking-wide font-600 mb-3 op50>
-            地点
-          </h2>
-          <template v-if="hasPreciseLocation(event)">
-            <div flex="~ items-center gap-3 justify-between" p-3 border border-gray-200 rounded-lg dark:border-gray-800>
-              <div text-sm op90 flex="~ items-center gap-1.5" min-w-0>
-                <div i-carbon-location op60 shrink-0 />
-                <span truncate>{{ event.venue }} · {{ event.city }}<template v-if="event.country !== '中国'"> · {{ event.country }}</template></span>
-              </div>
-              <button
-                type="button"
-                text-sm text-white px-3 py-1.5 rounded-md bg-teal-600 inline-flex shrink-0 gap-1.5 transition items-center hover:bg-teal-700
-                @click="copyAddress()"
-              >
-                <div :class="addressCopied ? 'i-carbon-checkmark' : 'i-carbon-copy'" />
-                {{ addressCopied ? '已复制' : '复制地址' }}
-              </button>
-            </div>
-
-            <EventMapEmbed v-if="event.coordinates" :coordinates="event.coordinates" :label="event.venue ?? event.city" mt-3 />
-
-            <div text-sm mt-3 op80 flex="~ wrap items-center gap-x-2 gap-y-1.5">
-              <span op60>在地图中打开：</span>
-              <a :href="amapSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
-                <div i-carbon-send-alt /> 高德地图
-              </a>
-              <a :href="baiduMapSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
-                <div i-simple-icons-baidu /> 百度地图
-              </a>
-              <a :href="appleMapsSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
-                <div i-simple-icons-apple /> Apple 地图
-              </a>
-            </div>
-          </template>
-          <div v-else p-3 border border-gray-200 rounded-lg dark:border-gray-800>
-            <div text-sm op90 flex="~ items-center gap-1.5">
-              <div i-carbon-location op60 shrink-0 />
-              {{ event.city }}<template v-if="event.country !== '中国'">
-                · {{ event.country }}
-              </template>
-            </div>
-            <div text-xs mt-1.5 op60 flex="~ items-center gap-1.5">
-              <div i-carbon-information shrink-0 /> 具体活动地点请查看官网信息。
-            </div>
-            <div
-              v-if="missingDetails.includes('venue')"
-              text-sm mt-3 pt-3 border-t border-gray-100 flex="~ wrap items-center gap-x-2 gap-y-1.5"
-              dark:border-gray-800
-            >
-              <span op65>知道具体场馆？欢迎帮大家补上。</span>
-              <ContributionMenu intent="edit" :event="event" label="补充地点" />
-            </div>
-          </div>
-        </section>
-
-        <section mt-8>
-          <h2 text-sm tracking-wide font-600 mb-3 op50>
-            相关链接
-          </h2>
-          <div v-if="resolvedLinks.length" flex="~ wrap gap-2">
-            <a
-              v-for="link in resolvedLinks" :key="link.url"
-              :href="link.url" target="_blank" rel="noopener"
-              hover="border-teal-600 text-teal-600" text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 transition items-center dark:border-gray-700
-            >
-              <div :class="link.icon" /> {{ link.label }}
-            </a>
-          </div>
+        <div v-if="theme" class="ev-watermark" aria-hidden="true">
           <div
-            v-else
-            flex="~ wrap items-center gap-x-2 gap-y-1.5"
-            text-sm p-3 border border-gray-300 rounded-lg border-dashed dark:border-gray-700
-          >
-            <div i-carbon-link op45 shrink-0 />
-            <span op65>暂时还没有收录报名、议程或官方社媒等相关链接。</span>
-            <ContributionMenu intent="edit" :event="event" label="补充相关链接" />
+            v-for="def in theme.icons.slice(1).reverse()"
+            :key="def.icon"
+            class="ev-icon-tinted" :class="[def.icon]"
+            :style="{ 'fontSize': '58px', 'marginRight': '-18px', 'marginBottom': '6px', '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }"
+          />
+          <div :class="theme.primary.icon" :style="{ fontSize: '105px', color: 'var(--ev-c)' }" />
+        </div>
+      </article>
+
+      <section class="official-strip" aria-label="活动官网">
+        <div class="official-copy">
+          <div i-carbon-launch aria-hidden="true" />
+          <div>
+            <h2>{{ past ? '回顾这场活动' : '准备参加这场活动？' }}</h2>
+            <p>{{ past ? '回顾资料与后续动态，请查看主办方官网。' : '报名方式、参与条件与最新安排，请以主办方官网为准。' }}</p>
           </div>
+        </div>
+        <a :href="event.url" target="_blank" rel="noopener" class="official-button">前往官网 <div i-carbon-arrow-up-right aria-hidden="true" /></a>
+      </section>
+
+      <div class="planning-grid">
+        <section class="facts-panel" aria-labelledby="facts-heading">
+          <div class="panel-kicker">
+            <div i-carbon-notebook aria-hidden="true" /> 活动信息
+          </div>
+          <h2 id="facts-heading">
+            {{ past ? '活动备忘' : '你的参会备忘' }}
+          </h2>
+          <dl class="event-facts">
+            <div>
+              <dt><div i-carbon-calendar aria-hidden="true" /> 日期</dt>
+              <dd>{{ formatDateRange(event.start, event.end) }}</dd>
+            </div>
+            <div>
+              <dt><div :class="event.format === 'online' ? 'i-carbon-video' : 'i-carbon-location'" aria-hidden="true" /> {{ event.format === 'online' && !event.venue ? '参与方式' : '地点' }}</dt>
+              <dd v-if="event.format === 'online' && !event.venue">
+                线上参与<small>参与入口请查看活动官网。</small>
+              </dd>
+              <dd v-else>
+                {{ event.venue || event.city }}
+                <small>{{ event.country }} · {{ event.city }}<template v-if="!event.venue"> · 具体场馆待补充</template></small>
+              </dd>
+            </div>
+            <div v-if="event.organizer">
+              <dt><div i-carbon-group aria-hidden="true" /> 主办方</dt>
+              <dd>{{ event.organizer }}</dd>
+            </div>
+          </dl>
         </section>
 
-        <section
-          class="mt-10 p-5 border border-teal-200 rounded-xl bg-teal-50/60 dark:border-teal-900 dark:bg-teal-950/25"
-        >
-          <div flex="~ items-start gap-3">
-            <div i-carbon-collaborate text-xl text-teal-600 mt-0.5 shrink-0 />
-            <div>
-              <h2 text-base font-700>
-                发现信息有误或想补充？
-              </h2>
-              <p text-sm mt-1 op70>
-                活动由社区共同维护。你可以直接编辑数据，也可以复制一份完整提示词，让 Agent 帮你调查和整理。
-              </p>
-              <div mt-4>
-                <ContributionMenu intent="edit" :event="event" trigger-style="primary" />
-              </div>
+        <section class="takeaway-panel" aria-labelledby="takeaway-heading">
+          <div class="panel-kicker">
+            <div i-carbon-document aria-hidden="true" /> 保存与分享
+          </div>
+          <h2 id="takeaway-heading">
+            {{ past ? '把活动信息带走' : '交给 Agent，接着规划。' }}
+          </h2>
+          <p>{{ past ? '复制完整活动信息，方便整理资料，或和朋友交流。' : event.format === 'online' ? '复制活动信息，让你的 Agent 帮你安排参与时间和关注的内容。' : '复制活动信息，让你的 Agent 帮你安排交通、住宿与参会日程。' }}</p>
+          <div class="export-preview" aria-label="导出内容摘要">
+            <div class="preview-title">
+              <div i-carbon-document-blank aria-hidden="true" /><span>{{ event.name }}</span><span class="file-format">.md</span>
             </div>
+            <p>日期、地点、活动介绍及已收录的相关链接</p>
+            <a :href="eventCanonicalUrl(event.id)" class="preview-source">附活动详情页来源链接 <div i-carbon-link aria-hidden="true" /></a>
+          </div>
+          <EventMarkdownButton :key="event.id" :event="event" variant="primary" />
+          <div class="secondary-actions">
+            <a :href="`/ics/${event.id}.ics`" download><div i-carbon-calendar-add aria-hidden="true" /> 加入日历</a>
+            <EventShareButtons :key="event.id" :url="eventCanonicalUrl(event.id)" :title="event.name" />
           </div>
         </section>
       </div>
+      <section
+        class="contribution-panel"
+      >
+        <div flex="~ items-start gap-3">
+          <div i-carbon-collaborate text-xl text-teal-600 mt-0.5 shrink-0 dark:text-teal-400 />
+          <div>
+            <h2 text-base font-700>
+              发现信息有误或想补充？
+            </h2>
+            <p text-sm mt-1 op70>
+              活动由社区共同维护。你可以直接编辑数据，也可以复制一份完整提示词，让 Agent 帮你调查和整理。
+            </p>
+            <div mt-4>
+              <ContributionMenu intent="edit" :event="event" trigger-style="primary" />
+            </div>
+          </div>
+        </div>
+      </section>
 
-      <RelatedEvents v-if="related.length" :key="event.id" :events="related" class="event-related" />
-      <EventComments :event-id="event.id" class="event-discussion" />
-    </div>
+      <div class="reading-layout" :class="{ 'has-related': related.length }">
+        <RelatedEvents v-if="related.length" :key="event.id" :events="related" class="event-related" />
+        <div class="tab-content">
+          <div id="detail-tabs" class="detail-tabs" role="tablist" aria-label="活动详情与讨论" @keydown.left.prevent="navigateTabs('ArrowLeft')" @keydown.right.prevent="navigateTabs('ArrowRight')" @keydown.home.prevent="navigateTabs('Home')" @keydown.end.prevent="navigateTabs('End')">
+            <button id="details-tab" role="tab" type="button" :aria-selected="activeTab === 'details'" aria-controls="details-panel" :tabindex="activeTab === 'details' ? 0 : -1" @click="selectTab('details')">
+              <div i-carbon-document aria-hidden="true" /> 活动详情
+            </button>
+            <button id="discussion-tab" role="tab" type="button" :aria-selected="activeTab === 'discussion'" aria-controls="discussion-panel" :tabindex="activeTab === 'discussion' ? 0 : -1" @click="selectTab('discussion')">
+              <div i-carbon-chat aria-hidden="true" /> 参与者讨论
+            </button>
+          </div>
+          <div id="details-panel" role="tabpanel" aria-labelledby="details-tab" :hidden="activeTab !== 'details'" tabindex="0">
+            <section class="event-intro" aria-labelledby="intro-heading">
+              <h2 id="intro-heading">
+                关于这场活动
+              </h2>
+              <p v-if="event.description">
+                {{ event.description }}
+              </p>
+              <div v-else class="missing-description">
+                <p>暂时还没有活动介绍，详情请查看官网。</p><ContributionMenu intent="edit" :event="event" label="补充介绍" />
+              </div>
+            </section>
+            <section v-if="hasLocation(event)" mt-8>
+              <h2 text-sm tracking-wide font-600 mb-3 op50>
+                地点
+              </h2>
+              <template v-if="hasPreciseLocation(event)">
+                <div flex="~ items-center gap-3 justify-between" p-3 border border-gray-200 rounded-lg dark:border-gray-800>
+                  <div text-sm op90 flex="~ items-center gap-1.5" min-w-0>
+                    <div i-carbon-location op60 shrink-0 />
+                    <span truncate>{{ event.venue }} · {{ event.city }}<template v-if="event.country !== '中国'"> · {{ event.country }}</template></span>
+                  </div>
+                  <button
+                    type="button"
+                    text-sm text-white px-3 py-1.5 rounded-md bg-teal-600 inline-flex shrink-0 gap-1.5 transition items-center hover:bg-teal-700
+                    @click="copyAddress()"
+                  >
+                    <div :class="addressCopied ? 'i-carbon-checkmark' : 'i-carbon-copy'" />
+                    {{ addressCopied ? '已复制' : '复制地址' }}
+                  </button>
+                </div>
 
+                <EventMapEmbed v-if="event.coordinates" :coordinates="event.coordinates" :label="event.venue ?? event.city" mt-3 />
+
+                <div text-sm mt-3 op80 flex="~ wrap items-center gap-x-2 gap-y-1.5">
+                  <span op60>在地图中打开：</span>
+                  <a :href="amapSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
+                    <div i-carbon-send-alt /> 高德地图
+                  </a>
+                  <a :href="baiduMapSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
+                    <div i-simple-icons-baidu /> 百度地图
+                  </a>
+                  <a :href="appleMapsSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
+                    <div i-simple-icons-apple /> Apple 地图
+                  </a>
+                </div>
+              </template>
+              <div v-else p-3 border border-gray-200 rounded-lg dark:border-gray-800>
+                <div text-sm op90 flex="~ items-center gap-1.5">
+                  <div i-carbon-location op60 shrink-0 />
+                  {{ event.city }}<template v-if="event.country !== '中国'">
+                    · {{ event.country }}
+                  </template>
+                </div>
+                <div text-xs mt-1.5 op60 flex="~ items-center gap-1.5">
+                  <div i-carbon-information shrink-0 /> 具体活动地点请查看官网信息。
+                </div>
+                <div
+                  v-if="missingDetails.includes('venue')"
+                  text-sm mt-3 pt-3 border-t border-gray-100 flex="~ wrap items-center gap-x-2 gap-y-1.5"
+                  dark:border-gray-800
+                >
+                  <span op65>知道具体场馆？欢迎帮大家补上。</span>
+                  <ContributionMenu intent="edit" :event="event" label="补充地点" />
+                </div>
+              </div>
+            </section>
+
+            <section mt-8>
+              <h2 text-sm tracking-wide font-600 mb-3 op50>
+                相关链接
+              </h2>
+              <div v-if="resolvedLinks.length" flex="~ wrap gap-2">
+                <a
+                  v-for="link in resolvedLinks" :key="link.url"
+                  :href="link.url" target="_blank" rel="noopener"
+                  hover="border-teal-600 text-teal-600" text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 transition items-center dark:border-gray-700
+                >
+                  <div :class="link.icon" /> {{ link.label }}
+                </a>
+              </div>
+              <div
+                v-else
+                flex="~ wrap items-center gap-x-2 gap-y-1.5"
+                text-sm p-3 border border-gray-300 rounded-lg border-dashed dark:border-gray-700
+              >
+                <div i-carbon-link op45 shrink-0 />
+                <span op65>暂时还没有收录报名、议程或官方社媒等相关链接。</span>
+                <ContributionMenu intent="edit" :event="event" label="补充相关链接" />
+              </div>
+            </section>
+
+            <div class="discussion-prompt">
+              <div><h3>和参与者聊聊</h3><p>找同行、聊见闻，或分享会后资料。</p></div><a href="#comments" @click.prevent="selectTab('discussion', true)">查看讨论 <div i-carbon-arrow-right aria-hidden="true" /></a>
+            </div>
+          </div>
+          <div id="discussion-panel" role="tabpanel" aria-labelledby="discussion-tab" :hidden="activeTab !== 'discussion'" tabindex="0">
+            <EventComments :event-id="event.id" class="event-discussion" />
+          </div>
+        </div>
+      </div>
+    </template>
     <div v-else mt-16 text-center op60>
       <div i-carbon-help text-4xl mx-auto mb-3 op50 />
       <p>活动不存在或已被移除。</p>
@@ -278,43 +344,455 @@ useHead(() => ({
 </template>
 
 <style scoped>
-.event-layout {
-  display: grid;
-  grid-template-areas: 'content' 'discussion';
-  gap: 2rem;
+.detail-page {
+  --detail-ink: #203e35;
+  --detail-muted: #677d72;
+  --detail-line: #dfe7e1;
+  --detail-surface: #fff;
+  --detail-soft: #f5f8f5;
+  --detail-accent: #0d806a;
+  --detail-action: #0d7664;
+  --detail-action-hover: #115e52;
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0 2rem 4rem;
+  color: var(--detail-ink);
 }
-
-.event-layout.has-related {
-  grid-template-areas: 'content' 'related' 'discussion';
+html.dark .detail-page {
+  --detail-ink: var(--colors-gray-200);
+  --detail-muted: var(--colors-gray-400);
+  --detail-line: var(--colors-gray-800);
+  --detail-surface: var(--colors-gray-900);
+  --detail-soft: var(--colors-gray-900);
+  --detail-accent: var(--colors-teal-400);
+  --detail-action: var(--colors-teal-700);
+  --detail-action-hover: var(--colors-teal-800);
 }
-
-.event-content {
-  grid-area: content;
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--detail-line);
+}
+.site-name {
+  display: block;
+  font-size: 1.1rem;
+  font-weight: 750;
+  letter-spacing: -0.04em;
+}
+.site-caption {
+  display: block;
+  font-size: 0.7rem;
+  color: var(--detail-muted);
+  margin-top: 0.15rem;
+}
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--detail-muted);
+  margin: 1.5rem 0;
+}
+.event-hero {
+  padding: 2.5rem;
+  border-radius: 1.35rem;
+  background: var(--detail-surface);
+}
+.hero-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+  font-size: 0.75rem;
+  color: var(--detail-muted);
+  margin-bottom: 1.3rem;
+}
+.hero-meta > span {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+.format-badge,
+.past-badge {
+  padding: 0.2rem 0.6rem;
+  border-radius: 2rem;
+  border: 1px solid var(--detail-line);
+}
+.past-badge {
+  background: var(--detail-soft);
+}
+h1 {
+  max-width: 53rem;
+  font-size: clamp(1.65rem, 3vw, 2.75rem);
+  letter-spacing: -0.035em;
+  line-height: 1.3;
+  font-weight: 750;
+  overflow-wrap: anywhere;
+}
+/** Preserve each event’s brand hue while making dark titles readable. */
+html.dark .event-hero .ev-title-themed {
+  color: color-mix(in srgb, var(--ev-c) 70%, white);
+}
+.event-hero :deep(.ev-watermark) {
+  right: 1rem;
+  bottom: -0.5rem;
+  opacity: 0.12;
+}
+.event-hero :deep(.ev-watermark > div:last-child) {
+  font-size: 9rem !important;
+}
+.official-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.2rem 1.5rem;
+  margin: 1rem 0 1.5rem;
+  border: 1px solid var(--detail-line);
+  border-radius: 1rem;
+  background: var(--detail-surface);
+}
+.official-copy {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
   min-width: 0;
 }
-
+.official-copy > div:first-child {
+  flex-shrink: 0;
+  color: var(--detail-accent);
+}
+.official-copy h2 {
+  font-size: 0.9rem;
+  font-weight: 650;
+}
+.official-copy p {
+  font-size: 0.75rem;
+  color: var(--detail-muted);
+  margin-top: 0.25rem;
+  line-height: 1.8;
+}
+.official-button {
+  display: inline-flex;
+  flex-shrink: 0;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.15rem;
+  border-radius: 0.65rem;
+  background: var(--detail-action);
+  color: white;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+.official-button:hover {
+  background: var(--detail-action-hover);
+}
+.planning-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+.facts-panel,
+.takeaway-panel {
+  min-width: 0;
+  padding: 1.75rem;
+  border: 1px solid var(--detail-line);
+  border-radius: 1.2rem;
+  background: var(--detail-surface);
+}
+.panel-kicker {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.7rem;
+  color: var(--detail-muted);
+  margin-bottom: 0.9rem;
+}
+.facts-panel h2,
+.takeaway-panel h2 {
+  font-size: 1.45rem;
+  letter-spacing: -0.025em;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+.event-facts {
+  margin: 0;
+}
+.event-facts > div {
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--detail-line);
+}
+.event-facts > div:last-child {
+  border: 0;
+  padding-bottom: 0;
+}
+.event-facts dt {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.7rem;
+  color: var(--detail-muted);
+  margin-bottom: 0.4rem;
+}
+.event-facts dd {
+  margin: 0 0 0 1.5rem;
+  font-size: 0.95rem;
+  font-weight: 550;
+  overflow-wrap: anywhere;
+  line-height: 1.75;
+}
+.event-facts small {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--detail-muted);
+  font-weight: 400;
+  margin-top: 0.25rem;
+}
+.takeaway-panel {
+  background: #edf4e9;
+  border-color: #dbe6d5;
+}
+html.dark .takeaway-panel {
+  background: color-mix(in srgb, var(--colors-teal-950) 35%, var(--detail-surface));
+  border-color: var(--detail-line);
+}
+.takeaway-panel > p {
+  color: var(--detail-muted);
+  font-size: 0.8rem;
+  line-height: 1.9;
+}
+.export-preview {
+  margin: 1.2rem 0;
+  padding: 1rem;
+  border: 1px solid var(--detail-line);
+  border-radius: 0.7rem;
+  background: var(--detail-surface);
+}
+.preview-title {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  font-size: 0.75rem;
+}
+.preview-title > div {
+  flex-shrink: 0;
+}
+.preview-title > span:not(.file-format) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.file-format {
+  margin-left: auto;
+  font-family: monospace;
+  color: var(--detail-muted);
+  flex-shrink: 0;
+}
+.export-preview p,
+.preview-source {
+  font-size: 0.7rem;
+  color: var(--detail-muted);
+  margin-top: 0.5rem;
+}
+.preview-source {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  text-decoration: underline;
+  text-underline-offset: 0.2rem;
+}
+.secondary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  padding-top: 0.7rem;
+  border-top: 1px solid var(--detail-line);
+}
+.secondary-actions > a,
+.secondary-actions :deep(button) {
+  display: inline-flex;
+  flex: 1 1 auto;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.4rem;
+  border: 0;
+  width: auto;
+  background: transparent;
+  color: var(--detail-ink);
+  font-size: 0.75rem;
+  border-radius: 0.5rem;
+}
+.secondary-actions > a:hover,
+.secondary-actions :deep(button:hover) {
+  background: var(--detail-surface);
+}
+.contribution-panel {
+  margin-top: 1.5rem;
+  padding: 1.4rem 1.5rem;
+  border: 1px solid var(--detail-line);
+  border-radius: 1rem;
+  background: var(--detail-soft);
+}
+.reading-layout {
+  display: grid;
+  grid-template-areas: 'tabs';
+  gap: 2rem;
+  margin-top: 2rem;
+}
+.reading-layout.has-related {
+  grid-template-columns: minmax(0, 1fr) 18rem;
+  grid-template-areas: 'tabs related';
+}
+.tab-content {
+  grid-area: tabs;
+  min-width: 0;
+}
 .event-related {
   grid-area: related;
   min-width: 0;
+  padding-top: 0.9rem;
 }
-
+.detail-tabs {
+  display: flex;
+  gap: 1.5rem;
+  border-bottom: 1px solid var(--detail-line);
+  scroll-margin-top: 1.5rem;
+}
+.detail-tabs > button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.85rem 0;
+  border-bottom: 2px solid transparent;
+  color: var(--detail-muted);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.detail-tabs > button[aria-selected='true'] {
+  color: var(--detail-accent);
+  border-bottom-color: var(--detail-accent);
+}
+.event-intro {
+  padding-top: 1.75rem;
+}
+.event-intro h2 {
+  font-size: 1.05rem;
+  font-weight: 650;
+  margin-bottom: 0.8rem;
+}
+.event-intro p {
+  font-size: 0.9rem;
+  line-height: 1.9;
+  color: var(--detail-muted);
+  white-space: pre-line;
+  overflow-wrap: anywhere;
+}
+.missing-description {
+  display: flex;
+  gap: 0.6rem;
+  flex-direction: column;
+  align-items: flex-start;
+}
 .event-discussion {
-  grid-area: discussion;
-  min-width: 0;
   margin-top: 0;
+  padding-top: 1.6rem;
+  border-top: 0;
 }
-
-@media (min-width: 1024px) {
-  .event-layout.has-related {
-    grid-template-columns: minmax(0, 1fr) 18rem;
-    grid-template-rows: min-content 1fr;
-    grid-template-areas: 'content related' 'discussion related';
-    column-gap: 3rem;
-    align-items: start;
+.discussion-prompt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding: 1.25rem 0;
+  border-top: 1px solid var(--detail-line);
+}
+.discussion-prompt h3 {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+.discussion-prompt p {
+  font-size: 0.75rem;
+  color: var(--detail-muted);
+  margin-top: 0.2rem;
+}
+.discussion-prompt a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--detail-accent);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+.detail-page :is(button, a, [tabindex]):focus-visible {
+  outline: 2px solid #36a48c;
+  outline-offset: 4px;
+}
+.detail-page :is([role='tabpanel'])[hidden] {
+  display: none;
+}
+@media (max-width: 1023px) {
+  .reading-layout.has-related {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas: 'related' 'tabs';
   }
-
   .event-related {
-    margin-top: 1rem;
+    padding-top: 0;
+  }
+}
+@media (max-width: 700px) {
+  .detail-page {
+    padding: 0 1.25rem 3rem;
+  }
+  .site-header {
+    padding: 1.1rem 0;
+  }
+  .back-link {
+    margin: 1.25rem 0;
+  }
+  .event-hero {
+    padding: 1.6rem 1.4rem;
+  }
+  .official-strip {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.25rem;
+  }
+  .official-copy {
+    align-items: flex-start;
+    gap: 0.7rem;
+  }
+  .official-copy > div:first-child {
+    margin-top: 0.2rem;
+  }
+  .planning-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1rem;
+  }
+  .facts-panel,
+  .takeaway-panel {
+    padding: 1.4rem;
+  }
+  .facts-panel h2,
+  .takeaway-panel h2 {
+    font-size: 1.3rem;
+  }
+  .contribution-panel {
+    padding: 1.25rem;
+  }
+  .reading-layout {
+    margin-top: 1.5rem;
+    gap: 1.5rem;
+  }
+  .discussion-prompt {
+    flex-wrap: wrap;
   }
 }
 </style>

--- a/src/pages/event/[id].vue
+++ b/src/pages/event/[id].vue
@@ -117,7 +117,7 @@ const past = computed(() => event.value ? isPast(event.value.end) : false)
             <p>{{ past ? '回顾资料与后续动态，请查看主办方官网。' : '报名方式、参与条件与最新安排，请以主办方官网为准。' }}</p>
           </div>
         </div>
-        <a :href="event.url" target="_blank" rel="noopener" class="official-button">前往官网 <div i-carbon-arrow-up-right aria-hidden="true" /></a>
+        <a :href="event.url" target="_blank" rel="noopener" class="official-button action-button">前往官网 <div i-carbon-arrow-up-right aria-hidden="true" /></a>
       </section>
 
       <div class="planning-grid">
@@ -167,7 +167,7 @@ const past = computed(() => event.value ? isPast(event.value.end) : false)
           </div>
           <EventMarkdownButton :key="event.id" :event="event" variant="primary" />
           <div class="secondary-actions">
-            <a :href="`/ics/${event.id}.ics`" download><div i-carbon-calendar-add aria-hidden="true" /> 加入日历</a>
+            <a :href="`/ics/${event.id}.ics`" download text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 transition items-center justify-center hover:text-teal-600 dark:border-gray-700 hover:border-teal-600><div i-carbon-calendar-add aria-hidden="true" /> 加入日历</a>
             <EventShareButtons :key="event.id" :url="eventCanonicalUrl(event.id)" :title="event.name" />
           </div>
         </section>
@@ -311,8 +311,6 @@ const past = computed(() => event.value ? isPast(event.value.end) : false)
   --detail-surface: #fff;
   --detail-soft: #f5f8f5;
   --detail-accent: #0d806a;
-  --detail-action: #0d7664;
-  --detail-action-hover: #115e52;
   max-width: 72rem;
   margin: 0 auto;
   padding: 0 2rem 4rem;
@@ -325,8 +323,6 @@ html.dark .detail-page {
   --detail-surface: var(--colors-gray-900);
   --detail-soft: var(--colors-gray-900);
   --detail-accent: var(--colors-teal-400);
-  --detail-action: var(--colors-teal-700);
-  --detail-action-hover: var(--colors-teal-800);
 }
 .site-header {
   display: flex;
@@ -435,20 +431,7 @@ html.dark .event-hero .ev-title-themed {
   line-height: 1.8;
 }
 .official-button {
-  display: inline-flex;
   flex-shrink: 0;
-  gap: 0.5rem;
-  align-items: center;
-  justify-content: center;
-  padding: 0.75rem 1.15rem;
-  border-radius: 0.65rem;
-  background: var(--detail-action);
-  color: white;
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-.official-button:hover {
-  background: var(--detail-action-hover);
 }
 .planning-grid {
   display: grid;
@@ -574,22 +557,8 @@ html.dark .takeaway-panel {
 }
 .secondary-actions > a,
 .secondary-actions :deep(button) {
-  display: inline-flex;
   flex: 1 1 auto;
-  align-items: center;
-  justify-content: center;
-  gap: 0.4rem;
-  padding: 0.5rem 0.4rem;
-  border: 0;
   width: auto;
-  background: transparent;
-  color: var(--detail-ink);
-  font-size: 0.75rem;
-  border-radius: 0.5rem;
-}
-.secondary-actions > a:hover,
-.secondary-actions :deep(button:hover) {
-  background: var(--detail-surface);
 }
 .contribution-panel {
   margin-top: 1.5rem;
@@ -635,7 +604,7 @@ html.dark .takeaway-panel {
   align-items: flex-start;
 }
 .detail-page :is(button, a, [tabindex]):focus-visible {
-  outline: 2px solid #36a48c;
+  outline: 2px solid var(--colors-teal-500);
   outline-offset: 4px;
 }
 @media (max-width: 1023px) {

--- a/src/pages/event/[id].vue
+++ b/src/pages/event/[id].vue
@@ -9,7 +9,6 @@ import { relatedEvents } from '~/utils/related'
 import { buildEventJsonLd, eventCanonicalUrl, eventOgImageUrl } from '~/utils/seo'
 
 const route = useRoute('/event/[id]')
-const router = useRouter()
 
 /** Prerendered files live at /event/<id>.html, so direct visits may carry the extension in the param; strip it so both URL forms resolve to the same event. */
 const eventId = computed(() => String(route.params.id).replace(/\.html$/, ''))
@@ -61,31 +60,6 @@ useHead(() => ({
 }))
 
 const past = computed(() => event.value ? isPast(event.value.end) : false)
-const activeTab = ref<'details' | 'discussion'>('details')
-
-/** Hash links open discussions after hydration, while ordinary event navigation resets the tab. */
-function syncTab() {
-  activeTab.value = route.hash === '#comments' ? 'discussion' : 'details'
-}
-onMounted(syncTab)
-watch(() => [eventId.value, route.hash], syncTab)
-
-/** Keep a shareable tab URL without moving the viewport on each tab switch. */
-async function selectTab(tab: 'details' | 'discussion', scroll = false) {
-  activeTab.value = tab
-  await router.replace({ hash: tab === 'discussion' ? '#comments' : '#details' })
-  if (scroll) {
-    await nextTick()
-    document.getElementById('detail-tabs')?.scrollIntoView({ block: 'start' })
-  }
-}
-
-/** Arrow keys and Home/End move focus and selection together, following the tabs pattern. */
-async function navigateTabs(key: string) {
-  const tab = key === 'Home' ? 'details' : key === 'End' ? 'discussion' : activeTab.value === 'details' ? 'discussion' : 'details'
-  await selectTab(tab)
-  document.getElementById(`${tab}-tab`)?.focus()
-}
 </script>
 
 <template>
@@ -219,16 +193,8 @@ async function navigateTabs(key: string) {
 
       <div class="reading-layout" :class="{ 'has-related': related.length }">
         <RelatedEvents v-if="related.length" :key="event.id" :events="related" class="event-related" />
-        <div class="tab-content">
-          <div id="detail-tabs" class="detail-tabs" role="tablist" aria-label="活动详情与讨论" @keydown.left.prevent="navigateTabs('ArrowLeft')" @keydown.right.prevent="navigateTabs('ArrowRight')" @keydown.home.prevent="navigateTabs('Home')" @keydown.end.prevent="navigateTabs('End')">
-            <button id="details-tab" role="tab" type="button" :aria-selected="activeTab === 'details'" aria-controls="details-panel" :tabindex="activeTab === 'details' ? 0 : -1" @click="selectTab('details')">
-              <div i-carbon-document aria-hidden="true" /> 活动详情
-            </button>
-            <button id="discussion-tab" role="tab" type="button" :aria-selected="activeTab === 'discussion'" aria-controls="discussion-panel" :tabindex="activeTab === 'discussion' ? 0 : -1" @click="selectTab('discussion')">
-              <div i-carbon-chat aria-hidden="true" /> 参与者讨论
-            </button>
-          </div>
-          <div id="details-panel" role="tabpanel" aria-labelledby="details-tab" :hidden="activeTab !== 'details'" tabindex="0">
+        <div class="reading-content">
+          <div id="details">
             <section class="event-intro" aria-labelledby="intro-heading">
               <h2 id="intro-heading">
                 关于这场活动
@@ -319,14 +285,8 @@ async function navigateTabs(key: string) {
                 <ContributionMenu intent="edit" :event="event" label="补充相关链接" />
               </div>
             </section>
-
-            <div class="discussion-prompt">
-              <div><h3>和参与者聊聊</h3><p>找同行、聊见闻，或分享会后资料。</p></div><a href="#comments" @click.prevent="selectTab('discussion', true)">查看讨论 <div i-carbon-arrow-right aria-hidden="true" /></a>
-            </div>
           </div>
-          <div id="discussion-panel" role="tabpanel" aria-labelledby="discussion-tab" :hidden="activeTab !== 'discussion'" tabindex="0">
-            <EventComments :event-id="event.id" class="event-discussion" />
-          </div>
+          <EventComments :event-id="event.id" />
         </div>
       </div>
     </template>
@@ -640,46 +600,21 @@ html.dark .takeaway-panel {
 }
 .reading-layout {
   display: grid;
-  grid-template-areas: 'tabs';
+  grid-template-areas: 'content';
   gap: 2rem;
   margin-top: 2rem;
 }
 .reading-layout.has-related {
   grid-template-columns: minmax(0, 1fr) 18rem;
-  grid-template-areas: 'tabs related';
+  grid-template-areas: 'content related';
 }
-.tab-content {
-  grid-area: tabs;
+.reading-content {
+  grid-area: content;
   min-width: 0;
 }
 .event-related {
   grid-area: related;
   min-width: 0;
-  padding-top: 0.9rem;
-}
-.detail-tabs {
-  display: flex;
-  gap: 1.5rem;
-  border-bottom: 1px solid var(--detail-line);
-  scroll-margin-top: 1.5rem;
-}
-.detail-tabs > button {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.85rem 0;
-  border-bottom: 2px solid transparent;
-  color: var(--detail-muted);
-  font-size: 0.9rem;
-  font-weight: 600;
-  cursor: pointer;
-}
-.detail-tabs > button[aria-selected='true'] {
-  color: var(--detail-accent);
-  border-bottom-color: var(--detail-accent);
-}
-.event-intro {
-  padding-top: 1.75rem;
 }
 .event-intro h2 {
   font-size: 1.05rem;
@@ -699,51 +634,14 @@ html.dark .takeaway-panel {
   flex-direction: column;
   align-items: flex-start;
 }
-.event-discussion {
-  margin-top: 0;
-  padding-top: 1.6rem;
-  border-top: 0;
-}
-.discussion-prompt {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-top: 2rem;
-  padding: 1.25rem 0;
-  border-top: 1px solid var(--detail-line);
-}
-.discussion-prompt h3 {
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-.discussion-prompt p {
-  font-size: 0.75rem;
-  color: var(--detail-muted);
-  margin-top: 0.2rem;
-}
-.discussion-prompt a {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  color: var(--detail-accent);
-  font-size: 0.8rem;
-  white-space: nowrap;
-}
 .detail-page :is(button, a, [tabindex]):focus-visible {
   outline: 2px solid #36a48c;
   outline-offset: 4px;
 }
-.detail-page :is([role='tabpanel'])[hidden] {
-  display: none;
-}
 @media (max-width: 1023px) {
   .reading-layout.has-related {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-areas: 'related' 'tabs';
-  }
-  .event-related {
-    padding-top: 0;
+    grid-template-areas: 'related' 'content';
   }
 }
 @media (max-width: 700px) {
@@ -790,9 +688,6 @@ html.dark .takeaway-panel {
   .reading-layout {
     margin-top: 1.5rem;
     gap: 1.5rem;
-  }
-  .discussion-prompt {
-    flex-wrap: wrap;
   }
 }
 </style>

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,13 +1,12 @@
 import type { RouterScrollBehavior } from 'vue-router'
 
 /**
- * Preserve the reading position for detail-page tab changes, including browser history.
- * New discussion deep links land on the tab bar after the page has mounted.
+ * Restore browser history positions and keep existing detail/discussion links navigable.
  */
-export const scrollBehavior: RouterScrollBehavior = (to, from, savedPosition) => {
+export const scrollBehavior: RouterScrollBehavior = (to, _from, savedPosition) => {
   if (savedPosition)
     return savedPosition
   if (to?.hash === '#comments' || to?.hash === '#details')
-    return to.path === from?.path ? false : { el: '#detail-tabs', top: 24 }
+    return { el: to.hash, top: 24 }
   return { top: 0 }
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,7 +1,13 @@
 import type { RouterScrollBehavior } from 'vue-router'
 
 /**
- * Keeps browser history navigation natural while ensuring every new page starts at the top.
+ * Preserve the reading position for detail-page tab changes, including browser history.
+ * New discussion deep links land on the tab bar after the page has mounted.
  */
-export const scrollBehavior: RouterScrollBehavior = (_to, _from, savedPosition) =>
-  savedPosition ?? { top: 0 }
+export const scrollBehavior: RouterScrollBehavior = (to, from, savedPosition) => {
+  if (savedPosition)
+    return savedPosition
+  if (to?.hash === '#comments' || to?.hash === '#details')
+    return to.path === from?.path ? false : { el: '#detail-tabs', top: 24 }
+  return { top: 0 }
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -13,6 +13,8 @@ export function formatDateRange(start: Date, end: Date): string {
     return fmtWithYear.format(start)
   if (start.getFullYear() === end.getFullYear() && start.getMonth() === end.getMonth())
     return `${fmtWithYear.format(start)} – ${end.getDate()}日`
+  if (start.getFullYear() !== end.getFullYear())
+    return `${fmtWithYear.format(start)} – ${fmtWithYear.format(end)}`
   return `${fmtWithYear.format(start)} – ${fmt.format(end)}`
 }
 

--- a/test/event-detail-c3.test.ts
+++ b/test/event-detail-c3.test.ts
@@ -41,6 +41,12 @@ async function openEvent(path = '/event/offline') {
 }
 
 describe('c3 event details', () => {
+  it('shares the existing primary button style for official and Markdown actions', async () => {
+    const { wrapper } = await openEvent()
+    expect(wrapper.get('.official-button').classes()).toContain('action-button')
+    expect(wrapper.getComponent(EventMarkdownButton).get('button').classes()).toContain('action-button')
+  })
+
   it('shows details followed by discussion without tabs or hidden panels', async () => {
     const { wrapper } = await openEvent()
     expect(wrapper.find('[role="tablist"]').exists()).toBe(false)

--- a/test/event-detail-c3.test.ts
+++ b/test/event-detail-c3.test.ts
@@ -41,33 +41,25 @@ async function openEvent(path = '/event/offline') {
 }
 
 describe('c3 event details', () => {
-  it('switches accessible tabs without hiding the shared tools or contribution entry', async () => {
-    const { wrapper, router } = await openEvent()
-    expect(wrapper.get('#details-tab').attributes('aria-selected')).toBe('true')
-    expect(wrapper.get('#discussion-panel').attributes('hidden')).toBeDefined()
-    await wrapper.get('#discussion-tab').trigger('click')
-    await flushPromises()
-    expect(router.currentRoute.value.hash).toBe('#comments')
-    expect(wrapper.get('#discussion-panel').attributes('hidden')).toBeUndefined()
-    expect(wrapper.get('#details-panel').attributes('hidden')).toBeDefined()
+  it('shows details followed by discussion without tabs or hidden panels', async () => {
+    const { wrapper } = await openEvent()
+    expect(wrapper.find('[role="tablist"]').exists()).toBe(false)
+    expect(wrapper.find('[role="tabpanel"]').exists()).toBe(false)
+    expect(wrapper.get('.event-intro').isVisible()).toBe(true)
+    const comments = wrapper.get('event-comments-stub')
+    expect(comments.isVisible()).toBe(true)
+    expect(wrapper.get('#details').element.compareDocumentPosition(comments.element) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(wrapper.getComponent(EventMarkdownButton).isVisible()).toBe(true)
     expect(wrapper.get('.contribution-panel').isVisible()).toBe(true)
-    await wrapper.get('#detail-tabs').trigger('keydown', { key: 'Home' })
-    await flushPromises()
-    expect(wrapper.get('#details-tab').attributes('tabindex')).toBe('0')
-    expect(document.activeElement?.id).toBe('details-tab')
-    expect(router.currentRoute.value.hash).toBe('#details')
-    await wrapper.get('#detail-tabs').trigger('keydown', { key: 'ArrowRight' })
-    await flushPromises()
-    expect(document.activeElement?.id).toBe('discussion-tab')
   })
 
-  it('opens discussion deep links and resets tabs when navigating to another event', async () => {
+  it('keeps details visible for discussion links and updates comments on event navigation', async () => {
     const { wrapper, router } = await openEvent('/event/offline.html#comments')
-    expect(wrapper.get('#discussion-tab').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('.event-intro').isVisible()).toBe(true)
+    expect(wrapper.get('event-comments-stub').isVisible()).toBe(true)
     await router.push('/event/online')
     await flushPromises()
-    expect(wrapper.get('#details-tab').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('.event-intro').isVisible()).toBe(true)
     expect(wrapper.get('event-comments-stub').attributes('eventid')).toBe('online')
   })
 
@@ -102,10 +94,10 @@ describe('c3 event details', () => {
     expect(wrapper.find('a[href*="amap"]').exists()).toBe(true)
   })
 
-  it('omits event actions and discussion tabs for an unknown event', async () => {
+  it('omits event actions and discussion for an unknown event', async () => {
     const { wrapper } = await openEvent('/event/missing')
     expect(wrapper.text()).toContain('活动不存在或已被移除')
-    expect(wrapper.find('[role="tablist"]').exists()).toBe(false)
+    expect(wrapper.find('event-comments-stub').exists()).toBe(false)
     expect(wrapper.findComponent(EventMarkdownButton).exists()).toBe(false)
   })
 })

--- a/test/event-detail-c3.test.ts
+++ b/test/event-detail-c3.test.ts
@@ -1,0 +1,111 @@
+import { createHead } from '@unhead/vue/client'
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import EventMarkdownButton from '~/components/EventMarkdownButton.vue'
+import EventDetail from '~/pages/event/[id].vue'
+
+vi.mock('~/composables/dark', () => ({ isDark: ref(false), toggleDark: vi.fn() }))
+vi.mock('~/composables/events', async () => {
+  const { normalizeEvent } = await import('~/utils/events')
+  return {
+    allEvents: [
+      normalizeEvent({ id: 'online', name: 'Online community', startDate: '2099-10-10', city: '线上', format: 'online', url: 'https://example.com' }, 'online'),
+      normalizeEvent({ id: 'offline', name: 'A very long Vue community conference title '.repeat(5), startDate: '2099-10-10', city: '上海', tags: ['vue'], url: 'https://example.com' }, 'offline'),
+      normalizeEvent({ id: 'past', name: 'Past hybrid conference', startDate: '2020-12-31', endDate: '2021-01-02', city: '东京', country: '日本', format: 'hybrid', venue: 'Conference hall', organizer: 'Community', description: 'Conference description', url: 'https://example.com' }, 'past'),
+    ],
+  }
+})
+
+const wrappers: ReturnType<typeof mount>[] = []
+afterEach(() => wrappers.splice(0).forEach(wrapper => wrapper.unmount()))
+
+async function openEvent(path = '/event/offline') {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/', component: { template: '<div />' } }, { path: '/event/:id', name: '/event/[id]', component: EventDetail }],
+  })
+  await router.push(path)
+  await router.isReady()
+  const wrapper = mount(EventDetail, {
+    attachTo: document.body,
+    global: {
+      plugins: [router, createHead()],
+      stubs: { ContributionMenu: true, RelatedEvents: true, EventMapEmbed: true, EventShareButtons: true, EventComments: true },
+    },
+  })
+  wrappers.push(wrapper)
+  await flushPromises()
+  return { wrapper, router }
+}
+
+describe('c3 event details', () => {
+  it('switches accessible tabs without hiding the shared tools or contribution entry', async () => {
+    const { wrapper, router } = await openEvent()
+    expect(wrapper.get('#details-tab').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('#discussion-panel').attributes('hidden')).toBeDefined()
+    await wrapper.get('#discussion-tab').trigger('click')
+    await flushPromises()
+    expect(router.currentRoute.value.hash).toBe('#comments')
+    expect(wrapper.get('#discussion-panel').attributes('hidden')).toBeUndefined()
+    expect(wrapper.get('#details-panel').attributes('hidden')).toBeDefined()
+    expect(wrapper.getComponent(EventMarkdownButton).isVisible()).toBe(true)
+    expect(wrapper.get('.contribution-panel').isVisible()).toBe(true)
+    await wrapper.get('#detail-tabs').trigger('keydown', { key: 'Home' })
+    await flushPromises()
+    expect(wrapper.get('#details-tab').attributes('tabindex')).toBe('0')
+    expect(document.activeElement?.id).toBe('details-tab')
+    expect(router.currentRoute.value.hash).toBe('#details')
+    await wrapper.get('#detail-tabs').trigger('keydown', { key: 'ArrowRight' })
+    await flushPromises()
+    expect(document.activeElement?.id).toBe('discussion-tab')
+  })
+
+  it('opens discussion deep links and resets tabs when navigating to another event', async () => {
+    const { wrapper, router } = await openEvent('/event/offline.html#comments')
+    expect(wrapper.get('#discussion-tab').attributes('aria-selected')).toBe('true')
+    await router.push('/event/online')
+    await flushPromises()
+    expect(wrapper.get('#details-tab').attributes('aria-selected')).toBe('true')
+    expect(wrapper.get('event-comments-stub').attributes('eventid')).toBe('online')
+  })
+
+  it('handles online-only events without inventing travel details or recommendations', async () => {
+    const { wrapper } = await openEvent('/event/online')
+    expect(wrapper.get('.event-facts').text()).toContain('线上参与')
+    expect(wrapper.get('.takeaway-panel').text()).toContain('安排参与时间')
+    expect(wrapper.get('.takeaway-panel').text()).not.toContain('住宿')
+    expect(wrapper.find('a[href*="amap"]').exists()).toBe(false)
+    expect(wrapper.find('related-events-stub').exists()).toBe(false)
+    expect(wrapper.find('.past-badge').exists()).toBe(false)
+  })
+
+  it('keeps full titles and theme icons while offering missing-data contributions', async () => {
+    const { wrapper } = await openEvent()
+    expect(wrapper.get('h1').text()).toBe('A very long Vue community conference title '.repeat(5).trim())
+    expect(wrapper.get('.event-hero').classes()).toContain('ev-themed')
+    expect(wrapper.get('.event-hero .ev-watermark').attributes('aria-hidden')).toBe('true')
+    expect(wrapper.get('.event-facts').text()).toContain('具体场馆待补充')
+    expect(wrapper.find('a[href*="amap"]').exists()).toBe(false)
+    expect(wrapper.get('.missing-description contribution-menu-stub').attributes('label')).toBe('补充介绍')
+  })
+
+  it('uses historical wording, full years and country details for past hybrid events', async () => {
+    const { wrapper } = await openEvent('/event/past')
+    expect(wrapper.get('.past-badge').text()).toBe('已结束')
+    expect(wrapper.get('.official-strip').text()).toContain('回顾这场活动')
+    expect(wrapper.get('.takeaway-panel').text()).toContain('整理资料')
+    expect(wrapper.get('.event-facts').text()).toContain('2020年12月31日 – 2021年1月2日')
+    expect(wrapper.get('.event-facts').text()).toContain('日本 · 东京')
+    expect(wrapper.get('.format-badge').text()).toBe('线上+线下')
+    expect(wrapper.find('a[href*="amap"]').exists()).toBe(true)
+  })
+
+  it('omits event actions and discussion tabs for an unknown event', async () => {
+    const { wrapper } = await openEvent('/event/missing')
+    expect(wrapper.text()).toContain('活动不存在或已被移除')
+    expect(wrapper.find('[role="tablist"]').exists()).toBe(false)
+    expect(wrapper.findComponent(EventMarkdownButton).exists()).toBe(false)
+  })
+})

--- a/test/event-detail-markdown.test.ts
+++ b/test/event-detail-markdown.test.ts
@@ -47,7 +47,7 @@ describe('event detail Markdown integration', () => {
         await flushPromises()
         const event = allEvents.find(event => event.id === id)!
         expect(wrapper.get('h1').text()).toBe(event.name)
-        expect(wrapper.get('a[href="#comments"]').text()).toContain('查看讨论')
+        expect(wrapper.get('#comments').isVisible()).toBe(true)
         expect(wrapper.getComponent(EventComments).props('eventId')).toBe(id)
         expect(wrapper.get('[data-testid="giscus"]').attributes('term')).toBe(`event:${id}`)
         await wrapper.getComponent(EventMarkdownButton).get('button').trigger('click')

--- a/test/event-detail-theme.test.ts
+++ b/test/event-detail-theme.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs'
+import { compileStyle, parse } from '@vue/compiler-sfc'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const { descriptor } = parse(readFileSync(`${process.cwd()}/src/pages/event/[id].vue`, 'utf8'))
+const compiled = compileStyle({ source: descriptor.styles[0]!.content, filename: 'event-detail.vue', id: 'data-v-theme-test', scoped: true })
+
+afterEach(() => {
+  document.documentElement.classList.remove('dark')
+  document.head.innerHTML = ''
+  document.body.innerHTML = ''
+})
+
+/** Exercise the compiled scoped selectors against the real html-level theme switch. */
+function mountStyles(dark: boolean) {
+  document.documentElement.classList.toggle('dark', dark)
+  const style = document.createElement('style')
+  style.textContent = compiled.code
+  document.head.append(style)
+  document.body.innerHTML = '<div class="detail-page" data-v-theme-test></div>'
+  return getComputedStyle(document.querySelector('.detail-page')!)
+}
+
+describe('event detail theme integration', () => {
+  it('inherits the shared dark palette through the html theme switch', () => {
+    const style = mountStyles(true)
+    expect(style.getPropertyValue('--detail-surface').trim()).toBe('var(--colors-gray-900)')
+    expect(style.getPropertyValue('--detail-ink').trim()).toBe('var(--colors-gray-200)')
+    expect(style.getPropertyValue('--detail-line').trim()).toBe('var(--colors-gray-800)')
+  })
+
+  it('keeps the approved light surfaces when dark mode is off', () => {
+    const style = mountStyles(false)
+    expect(style.getPropertyValue('--detail-surface').trim()).toBe('#fff')
+    expect(style.getPropertyValue('--detail-ink').trim()).toBe('#203e35')
+  })
+})

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { parseDay } from '~/utils/events'
+import { formatDateRange } from '~/utils/format'
+
+describe('formatDateRange', () => {
+  it('retains both years for trips crossing a year boundary', () => {
+    expect(formatDateRange(parseDay('2026-12-31'), parseDay('2027-01-02')))
+      .toBe('2026年12月31日 – 2027年1月2日')
+  })
+
+  it('keeps single-day and same-month ranges compact', () => {
+    expect(formatDateRange(parseDay('2026-09-22'), parseDay('2026-09-22'))).toBe('2026年9月22日')
+    expect(formatDateRange(parseDay('2026-09-22'), parseDay('2026-09-24'))).toBe('2026年9月22日 – 24日')
+  })
+})

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -14,10 +14,11 @@ describe('scrollBehavior', () => {
     expect(scrollBehavior(route, route, savedPosition)).toBe(savedPosition)
   })
 
-  it('preserves scroll when switching detail tabs and scrolls new deep links to the tabs', () => {
+  it('scrolls detail and discussion links to their sections', () => {
     const details = { path: '/event/vueconf', hash: '#details' } as never
     const discussion = { path: '/event/vueconf', hash: '#comments' } as never
-    expect(scrollBehavior(discussion, details, null)).toBe(false)
-    expect(scrollBehavior(discussion, route, null)).toEqual({ el: '#detail-tabs', top: 24 })
+    expect(scrollBehavior(discussion, details, null)).toEqual({ el: '#comments', top: 24 })
+    expect(scrollBehavior(details, discussion, null)).toEqual({ el: '#details', top: 24 })
+    expect(scrollBehavior(discussion, route, null)).toEqual({ el: '#comments', top: 24 })
   })
 })

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -13,4 +13,11 @@ describe('scrollBehavior', () => {
 
     expect(scrollBehavior(route, route, savedPosition)).toBe(savedPosition)
   })
+
+  it('preserves scroll when switching detail tabs and scrolls new deep links to the tabs', () => {
+    const details = { path: '/event/vueconf', hash: '#details' } as never
+    const discussion = { path: '/event/vueconf', hash: '#comments' } as never
+    expect(scrollBehavior(discussion, details, null)).toBe(false)
+    expect(scrollBehavior(discussion, route, null)).toEqual({ el: '#detail-tabs', top: 24 })
+  })
 })

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -8,6 +8,7 @@ import {
 
 export default defineConfig({
   shortcuts: [
+    ['action-button', 'text-sm text-white px-3 py-2 rounded-md bg-teal-600 inline-flex gap-1.5 transition items-center justify-center hover:bg-teal-700'],
     ['icon-btn', 'inline-flex items-center justify-center text-lg op75 hover:op100 hover:text-teal-600 transition cursor-pointer select-none'],
     ['chip', 'inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-sm border border-gray-200 dark:border-gray-700 select-none cursor-pointer transition'],
     ['chip-active', 'bg-teal-600 border-teal-600 text-white hover:bg-teal-700'],


### PR DESCRIPTION
## What this PR changes

- [x] Other (feature / UI improvement)

Event details now group the event facts, Markdown export, calendar download, and sharing actions into a planning area, with a separate official-site call to action. The community contribution entry stays above the reading area. Event details and comments form one continuous page, with discussion immediately following the event information and related links.

The page reuses the existing event icons, themed hero, related-event cards, contribution menu, and Giscus comments. Related events appear beside the reading area on desktop and in a horizontal carousel above the reading area on mobile. Dark mode uses the existing gray/teal palette, with brighter event titles for readability. Official-site and Markdown actions share the existing contribution-button style; secondary actions retain the existing sharing-button hover colors and borders.

Existing detail and discussion links scroll directly to their sections. Online events, missing venue/description/links, past events, long titles, unknown event IDs, and cross-year date ranges are handled explicitly.

## Validation

- [x] `pnpm run lint --fix`
- [x] `pnpm run typecheck`
- [x] 85 tests pass, including continuous discussion visibility, section links, missing data, cross-year dates, and compiled dark-mode selectors
- [x] Desktop and 390px mobile checks in light and dark modes, including the discussion area and related-event carousel
- [x] Production build and prerendering

No event-data changes.
