### PR TITLE
feat: add event planning sidebar and responsive detail layout

### DIFF
--- a/docs/ui-style.md
+++ b/docs/ui-style.md
@@ -1,0 +1,13 @@
+# UI styling conventions
+
+Inspect existing components before introducing styles. Prefer the current UnoCSS utilities and shortcuts over new colors, type sizes, or spacing values.
+
+- Standard cards: use `card` from `uno.config.ts` (white / gray-900).
+- Secondary information panels (including saving/sharing): use the location panel’s transparent background, gray-200 / gray-800 border, and rounded-lg.
+- Action panels: use `action-panel`, based on the original contribution panel (teal-50/60 / teal-950/25, p-5, rounded-xl).
+- Action-panel headings: text-base, font-700. Supporting copy: text-sm, mt-1, op70. Metadata: text-xs, op60. Inherit the App text color (gray-700 / gray-200).
+- Primary actions: use `action-button`, based on ContributionMenu (text-sm, px-3, py-2, rounded-md, teal-600 with teal-700 hover).
+- Secondary actions: retain EventShareButtons styling (text-sm, px-3, py-1.5, rounded-md and the existing light/dark borders). Do not override child buttons with custom font sizes, padding, or colors.
+- Keep brand colors and icons in the existing event theme system.
+
+Check desktop and mobile in both themes. Compare computed panel backgrounds, borders, padding, typography, and button sizes with an existing reference component; screenshots alone are insufficient to catch subtle drift.

--- a/src/components/ContributionMenu.vue
+++ b/src/components/ContributionMenu.vue
@@ -64,7 +64,7 @@ const copyDescription = computed(() =>
 const triggerClass = computed(() => ({
   icon: 'icon-btn',
   link: 'text-teal-600 inline-flex gap-1 items-center hover:underline',
-  primary: 'text-sm text-white px-3 py-2 rounded-md bg-teal-600 inline-flex gap-1.5 transition items-center justify-center hover:bg-teal-700',
+  primary: 'action-button',
   secondary: 'text-sm px-3 py-2 border border-gray-200 rounded-md inline-flex gap-1.5 transition items-center justify-center hover:text-teal-600 hover:border-teal-600 dark:border-gray-700',
 })[triggerStyle])
 

--- a/src/components/EventMarkdownButton.vue
+++ b/src/components/EventMarkdownButton.vue
@@ -2,7 +2,7 @@
 import type { NormalizedEvent } from '~/types'
 import { eventMarkdown } from '~/utils/eventMarkdown'
 
-const { event } = defineProps<{ event: NormalizedEvent }>()
+const { event, variant = 'default' } = defineProps<{ event: NormalizedEvent, variant?: 'default' | 'primary' }>()
 const copied = ref(false)
 const failed = ref(false)
 const { start: resetCopied } = useTimeoutFn(() => copied.value = false, 1500, { immediate: false })
@@ -25,8 +25,8 @@ async function copyMarkdown() {
 <template>
   <button
     type="button"
+    :class="variant === 'primary' ? 'action-button w-full' : 'text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 w-full transition items-center justify-center dark:border-gray-700 hover:border-teal-600 hover:text-teal-600'"
     title="复制完整活动信息，方便交给 Agent 规划行程"
-    hover="border-teal-600 text-teal-600" text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 w-full transition items-center justify-center dark:border-gray-700
     @click="copyMarkdown"
   >
     <div :class="copied && !failed ? 'i-carbon-checkmark' : 'i-carbon-copy'" aria-hidden="true" />

--- a/src/pages/event/[id].vue
+++ b/src/pages/event/[id].vue
@@ -58,212 +58,233 @@ useHead(() => ({
     ? [{ type: 'application/ld+json', innerHTML: JSON.stringify(buildEventJsonLd(event.value)).replace(/</g, '\\u003C') }]
     : [],
 }))
+
+const past = computed(() => event.value ? isPast(event.value.end) : false)
 </script>
 
 <template>
-  <div mx-auto px-4 pb-16 max-w-3xl :class="related.length ? 'lg:max-w-6xl' : ''">
-    <header pt-6 flex="~ items-center justify-between gap-3">
-      <RouterLink to="/" title="返回首页" class="group">
-        <span text-base tracking-tight font-700 transition group-hover:text-teal-600>techevent-cn</span>
-        <span text-xs op60 block>中国（及周边）科技活动日历</span>
+  <div class="detail-page">
+    <header class="site-header">
+      <RouterLink to="/" title="返回首页">
+        <span class="site-name">techevent-cn</span>
+        <span class="site-caption">中国（及周边）科技活动日历</span>
       </RouterLink>
-      <button class="icon-btn" title="切换暗色模式" @click="toggleDark()">
+      <button class="icon-btn" title="切换暗色模式" aria-label="切换暗色模式" @click="toggleDark()">
         <div i-carbon-sun dark:i-carbon-moon />
       </button>
     </header>
+    <RouterLink to="/" class="back-link">
+      <div i-carbon-arrow-left aria-hidden="true" /> 返回活动列表
+    </RouterLink>
 
-    <div v-if="!event" mt-4>
-      <RouterLink to="/" text-sm op60 inline-flex gap-1 items-center hover:text-teal-600 hover:op100>
-        <div i-carbon-arrow-left /> 返回活动列表
-      </RouterLink>
-    </div>
-
-    <div v-if="event" class="event-layout" :class="{ 'has-related': related.length }">
-      <div class="event-content">
-        <div flex="~ items-center" text-sm leading-5 mt-4>
-          <RouterLink to="/" text-sm op60 inline-flex gap-1 items-center hover:text-teal-600 hover:op100>
-            <div i-carbon-arrow-left /> 返回活动列表
-          </RouterLink>
-        </div>
-        <article
-          class="card" mt-4 p-6 relative
-          :class="theme ? 'ev-themed' : ''" :style="themeStyle"
-        >
-          <div flex="~ items-start justify-between gap-3">
-            <h1 text-2xl leading-snug font-700 :class="theme ? 'ev-title-themed' : ''">
-              {{ event.name }}
-            </h1>
-            <span text-xs mt-2 op70 shrink-0>{{ formatLabel[event.format] }}</span>
-          </div>
-
-          <div flex="~ col gap-1.5" text-sm mt-4 op80>
-            <span flex="~ items-center gap-1.5">
-              <div i-carbon-calendar shrink-0 /> {{ formatDateRange(event.start, event.end) }}
-              <span v-if="isPast(event.end)" text-xs px-1.5 rounded bg-gray-100 op70 dark:bg-gray-800>已结束</span>
-            </span>
-            <span flex="~ items-center gap-1.5">
-              <div i-carbon-location shrink-0 />
-              {{ event.city }}<template v-if="event.country !== '中国'"> · {{ event.country }}</template><template v-if="event.venue"> · {{ event.venue }}</template>
-            </span>
-            <span v-if="event.organizer" flex="~ items-center gap-1.5">
-              <div i-carbon-group shrink-0 /> {{ event.organizer }}
-            </span>
-          </div>
-
-          <p v-if="event.description" text-base leading-relaxed mt-4 op80>
-            {{ event.description }}
-          </p>
-
-          <div v-if="event.tags.length" mt-4 flex="~ wrap gap-1.5">
-            <span
-              v-for="{ tag, def } in taggedChips" :key="tag"
-              bg="gray-100 dark:gray-800"
-              text-xs px-2 py-0.5 rounded op80 inline-flex gap-1 items-center
-            >
-              <div v-if="def" :class="def.icon" class="ev-icon-tinted" text-xs :style="{ '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }" />
-              {{ tag }}
-            </span>
-          </div>
-
-          <div v-if="theme" class="ev-watermark" aria-hidden="true">
-            <div
-              v-for="def in theme.icons.slice(1).reverse()"
-              :key="def.icon"
-              class="ev-icon-tinted" :class="[def.icon]"
-              :style="{ 'fontSize': '58px', 'marginRight': '-18px', 'marginBottom': '6px', '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }"
-            />
-            <div :class="theme.primary.icon" :style="{ fontSize: '105px', color: 'var(--ev-c)' }" />
-          </div>
-        </article>
-
-        <div grid="~ cols-2 sm:cols-4 gap-2" mt-3>
-          <a
-            :href="event.url" target="_blank" rel="noopener"
-            text-sm text-white px-3 py-1.5 rounded-md bg-teal-600 inline-flex gap-1 w-full transition items-center justify-center hover:bg-teal-700
+    <div v-if="event" class="hybrid-layout">
+      <div class="main-column">
+        <div class="overview-stack">
+          <article
+            id="details" class="event-overview card" p-6 relative
+            :class="theme ? 'ev-themed' : ''" :style="themeStyle"
           >
-            前往官网 <div i-carbon-arrow-up-right />
-          </a>
-          <a
-            :href="`/ics/${event.id}.ics`"
-            hover="border-teal-600 text-teal-600" download text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 w-full transition items-center justify-center dark:border-gray-700
-          >
-            <div i-carbon-calendar-add /> 加入日历
-          </a>
-          <EventShareButtons :url="eventCanonicalUrl(event.id)" :title="event.name" />
-          <EventMarkdownButton :event="event" />
-        </div>
-
-        <div mt-4 flex="~ justify-end">
-          <a href="#comments" text-sm text-teal-700 py-2 inline-flex gap-1.5 items-center dark:text-teal-400 hover:underline>
-            <div i-carbon-chat aria-hidden="true" /> 查看讨论
-            <div i-carbon-arrow-down aria-hidden="true" />
-          </a>
-        </div>
-
-        <section v-if="hasLocation(event)" mt-8>
-          <h2 text-sm tracking-wide font-600 mb-3 op50>
-            地点
-          </h2>
-          <template v-if="hasPreciseLocation(event)">
-            <div flex="~ items-center gap-3 justify-between" p-3 border border-gray-200 rounded-lg dark:border-gray-800>
-              <div text-sm op90 flex="~ items-center gap-1.5" min-w-0>
-                <div i-carbon-location op60 shrink-0 />
-                <span truncate>{{ event.venue }} · {{ event.city }}<template v-if="event.country !== '中国'"> · {{ event.country }}</template></span>
-              </div>
-              <button
-                type="button"
-                text-sm text-white px-3 py-1.5 rounded-md bg-teal-600 inline-flex shrink-0 gap-1.5 transition items-center hover:bg-teal-700
-                @click="copyAddress()"
-              >
-                <div :class="addressCopied ? 'i-carbon-checkmark' : 'i-carbon-copy'" />
-                {{ addressCopied ? '已复制' : '复制地址' }}
-              </button>
+            <div flex="~ items-start justify-between gap-3">
+              <h1 text-2xl leading-snug font-700 :class="theme ? 'ev-title-themed' : ''">
+                {{ event.name }}
+              </h1>
+              <span class="format-label" text-xs mt-2 op70 shrink-0>{{ formatLabel[event.format] }}</span>
             </div>
 
-            <EventMapEmbed v-if="event.coordinates" :coordinates="event.coordinates" :label="event.venue ?? event.city" mt-3 />
+            <div flex="~ col gap-1.5" text-sm mt-4 op80>
+              <span flex="~ items-center gap-1.5">
+                <div i-carbon-calendar shrink-0 /> {{ formatDateRange(event.start, event.end) }}
+                <span v-if="isPast(event.end)" class="past-label" text-xs px-1.5 rounded bg-gray-100 op70 dark:bg-gray-800>已结束</span>
+              </span>
+              <span flex="~ items-center gap-1.5">
+                <div :class="event.format === 'online' ? 'i-carbon-video' : 'i-carbon-location'" shrink-0 />
+                {{ event.format === 'online' ? '线上参与' : event.city }}<template v-if="event.country !== '中国'"> · {{ event.country }}</template><template v-if="event.venue"> · {{ event.venue }}</template><template v-else-if="event.format !== 'online'"> · 具体场馆待补充</template>
+              </span>
+              <span v-if="event.organizer" flex="~ items-center gap-1.5">
+                <div i-carbon-group shrink-0 /> {{ event.organizer }}
+              </span>
+            </div>
 
-            <div text-sm mt-3 op80 flex="~ wrap items-center gap-x-2 gap-y-1.5">
-              <span op60>在地图中打开：</span>
-              <a :href="amapSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
-                <div i-carbon-send-alt /> 高德地图
-              </a>
-              <a :href="baiduMapSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
-                <div i-simple-icons-baidu /> 百度地图
-              </a>
-              <a :href="appleMapsSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
-                <div i-simple-icons-apple /> Apple 地图
-              </a>
-            </div>
-          </template>
-          <div v-else p-3 border border-gray-200 rounded-lg dark:border-gray-800>
-            <div text-sm op90 flex="~ items-center gap-1.5">
-              <div i-carbon-location op60 shrink-0 />
-              {{ event.city }}<template v-if="event.country !== '中国'">
-                · {{ event.country }}
-              </template>
-            </div>
-            <div text-xs mt-1.5 op60 flex="~ items-center gap-1.5">
-              <div i-carbon-information shrink-0 /> 具体活动地点请查看官网信息。
-            </div>
-            <div
-              v-if="missingDetails.includes('venue')"
-              text-sm mt-3 pt-3 border-t border-gray-100 flex="~ wrap items-center gap-x-2 gap-y-1.5"
-              dark:border-gray-800
-            >
-              <span op65>知道具体场馆？欢迎帮大家补上。</span>
-              <ContributionMenu intent="edit" :event="event" label="补充地点" />
-            </div>
-          </div>
-        </section>
-
-        <section mt-8>
-          <h2 text-sm tracking-wide font-600 mb-3 op50>
-            相关链接
-          </h2>
-          <div v-if="resolvedLinks.length" flex="~ wrap gap-2">
-            <a
-              v-for="link in resolvedLinks" :key="link.url"
-              :href="link.url" target="_blank" rel="noopener"
-              hover="border-teal-600 text-teal-600" text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 transition items-center dark:border-gray-700
-            >
-              <div :class="link.icon" /> {{ link.label }}
+            <a href="#comments" class="discussion-shortcut" text-sm text-teal-700 mt-2 py-2 inline-flex gap-1.5 items-center dark:text-teal-400 hover:underline>
+              <div i-carbon-chat aria-hidden="true" /> 查看讨论 <div i-carbon-arrow-down aria-hidden="true" />
             </a>
-          </div>
-          <div
-            v-else
-            flex="~ wrap items-center gap-x-2 gap-y-1.5"
-            text-sm p-3 border border-gray-300 rounded-lg border-dashed dark:border-gray-700
-          >
-            <div i-carbon-link op45 shrink-0 />
-            <span op65>暂时还没有收录报名、议程或官方社媒等相关链接。</span>
-            <ContributionMenu intent="edit" :event="event" label="补充相关链接" />
-          </div>
-        </section>
 
-        <section
-          class="mt-10 p-5 border border-teal-200 rounded-xl bg-teal-50/60 dark:border-teal-900 dark:bg-teal-950/25"
-        >
-          <div flex="~ items-start gap-3">
-            <div i-carbon-collaborate text-xl text-teal-600 mt-0.5 shrink-0 />
-            <div>
-              <h2 text-base font-700>
-                发现信息有误或想补充？
-              </h2>
-              <p text-sm mt-1 op70>
-                活动由社区共同维护。你可以直接编辑数据，也可以复制一份完整提示词，让 Agent 帮你调查和整理。
-              </p>
-              <div mt-4>
-                <ContributionMenu intent="edit" :event="event" trigger-style="primary" />
+            <p v-if="event.description" class="overview-description" text-base leading-relaxed mt-4 op80>
+              {{ event.description }}
+            </p>
+
+            <div v-if="!event.description" class="missing-description" text-sm mt-4>
+              <span op60>暂时还没有活动介绍，详情请查看官网。</span>
+              <ContributionMenu intent="edit" :event="event" label="补充介绍" />
+            </div>
+            <div v-if="event.tags.length" mt-4 flex="~ wrap gap-1.5">
+              <span
+                v-for="{ tag, def } in taggedChips" :key="tag"
+                bg="gray-100 dark:gray-800"
+                text-xs px-2 py-0.5 rounded op80 inline-flex gap-1 items-center
+              >
+                <div v-if="def" :class="def.icon" class="ev-icon-tinted" text-xs :style="{ '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }" />
+                {{ tag }}
+              </span>
+            </div>
+
+            <div v-if="theme" class="ev-watermark" aria-hidden="true">
+              <div
+                v-for="def in theme.icons.slice(1).reverse()"
+                :key="def.icon"
+                class="ev-icon-tinted" :class="[def.icon]"
+                :style="{ 'fontSize': '58px', 'marginRight': '-18px', 'marginBottom': '6px', '--ev-icon-c': def.color, '--ev-icon-c-dark': def.colorDark }"
+              />
+              <div :class="theme.primary.icon" :style="{ fontSize: '105px', color: 'var(--ev-c)' }" />
+            </div>
+          </article>
+
+          <section class="official-strip action-panel" aria-label="活动官网">
+            <div class="official-copy">
+              <div i-carbon-launch text-xl text-teal-600 mt-0.5 shrink-0 aria-hidden="true" />
+              <div>
+                <h2 text-base font-700>
+                  {{ past ? '回顾这场活动' : '准备参加这场活动？' }}
+                </h2>
+                <p text-sm mt-1 op70>
+                  {{ past ? '回顾资料与后续动态，请查看主办方官网。' : '报名方式、参与条件与最新安排，请以主办方官网为准。' }}
+                </p>
               </div>
             </div>
+            <a :href="event.url" target="_blank" rel="noopener" class="official-button action-button">前往官网 <div i-carbon-arrow-up-right aria-hidden="true" /></a>
+          </section>
+        </div>
+        <div class="supplemental-information">
+          <section v-if="hasLocation(event)" mt-8>
+            <h2 text-sm tracking-wide font-600 mb-3 op50>
+              地点
+            </h2>
+            <template v-if="hasPreciseLocation(event)">
+              <div flex="~ items-center gap-3 justify-between" p-3 border border-gray-200 rounded-lg dark:border-gray-800>
+                <div text-sm op90 flex="~ items-center gap-1.5" min-w-0>
+                  <div i-carbon-location op60 shrink-0 />
+                  <span truncate>{{ event.venue }} · {{ event.city }}<template v-if="event.country !== '中国'"> · {{ event.country }}</template></span>
+                </div>
+                <button
+                  type="button"
+                  text-sm text-white px-3 py-1.5 rounded-md bg-teal-600 inline-flex shrink-0 gap-1.5 transition items-center hover:bg-teal-700
+                  @click="copyAddress()"
+                >
+                  <div :class="addressCopied ? 'i-carbon-checkmark' : 'i-carbon-copy'" />
+                  {{ addressCopied ? '已复制' : '复制地址' }}
+                </button>
+              </div>
+
+              <EventMapEmbed v-if="event.coordinates" :coordinates="event.coordinates" :label="event.venue ?? event.city" mt-3 />
+
+              <div text-sm mt-3 op80 flex="~ wrap items-center gap-x-2 gap-y-1.5">
+                <span op60>在地图中打开：</span>
+                <a :href="amapSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
+                  <div i-carbon-send-alt /> 高德地图
+                </a>
+                <a :href="baiduMapSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
+                  <div i-simple-icons-baidu /> 百度地图
+                </a>
+                <a :href="appleMapsSearchUrl(mapQuery)" target="_blank" rel="noopener" class="chip chip-idle">
+                  <div i-simple-icons-apple /> Apple 地图
+                </a>
+              </div>
+            </template>
+            <div v-else p-3 border border-gray-200 rounded-lg dark:border-gray-800>
+              <div text-sm op90 flex="~ items-center gap-1.5">
+                <div i-carbon-location op60 shrink-0 />
+                {{ event.city }}<template v-if="event.country !== '中国'">
+                  · {{ event.country }}
+                </template>
+              </div>
+              <div text-xs mt-1.5 op60 flex="~ items-center gap-1.5">
+                <div i-carbon-information shrink-0 /> 具体活动地点请查看官网信息。
+              </div>
+              <div
+                v-if="missingDetails.includes('venue')"
+                text-sm mt-3 pt-3 border-t border-gray-100 flex="~ wrap items-center gap-x-2 gap-y-1.5"
+                dark:border-gray-800
+              >
+                <span op65>知道具体场馆？欢迎帮大家补上。</span>
+                <ContributionMenu intent="edit" :event="event" label="补充地点" />
+              </div>
+            </div>
+          </section>
+
+          <section mt-8>
+            <h2 text-sm tracking-wide font-600 mb-3 op50>
+              相关链接
+            </h2>
+            <div v-if="resolvedLinks.length" flex="~ wrap gap-2">
+              <a
+                v-for="link in resolvedLinks" :key="link.url"
+                :href="link.url" target="_blank" rel="noopener"
+                hover="border-teal-600 text-teal-600" text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 transition items-center dark:border-gray-700
+              >
+                <div :class="link.icon" /> {{ link.label }}
+              </a>
+            </div>
+            <div
+              v-else
+              flex="~ wrap items-center gap-x-2 gap-y-1.5"
+              text-sm p-3 border border-gray-300 rounded-lg border-dashed dark:border-gray-700
+            >
+              <div i-carbon-link op45 shrink-0 />
+              <span op65>暂时还没有收录报名、议程或官方社媒等相关链接。</span>
+              <ContributionMenu intent="edit" :event="event" label="补充相关链接" />
+            </div>
+          </section>
+
+          <section
+            class="contribution-panel action-panel"
+          >
+            <div flex="~ items-start gap-3">
+              <div i-carbon-collaborate text-xl text-teal-600 mt-0.5 shrink-0 />
+              <div>
+                <h2 text-base font-700>
+                  发现信息有误或想补充？
+                </h2>
+                <p text-sm mt-1 op70>
+                  活动由社区共同维护。你可以直接编辑数据，也可以复制一份完整提示词，让 Agent 帮你调查和整理。
+                </p>
+                <div mt-4>
+                  <ContributionMenu intent="edit" :event="event" trigger-style="primary" />
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+        <EventComments :event-id="event.id" class="event-discussion" />
+      </div>
+      <aside class="side-column" aria-label="保存与探索">
+        <section class="takeaway-panel p-5 border border-gray-200 rounded-lg bg-transparent dark:border-gray-800" aria-labelledby="takeaway-heading">
+          <div class="panel-kicker" text-xs mb-2 op60 flex="~ items-center gap-1.5">
+            <div i-carbon-document aria-hidden="true" /> 保存与分享
+          </div>
+          <h2 id="takeaway-heading" text-base font-700>
+            {{ past ? '把活动信息带走' : '交给 Agent，接着规划。' }}
+          </h2>
+          <p text-sm mt-1 op70>
+            {{ past ? '复制完整活动信息，方便整理资料，或和朋友交流。' : event.format === 'online' ? '复制活动信息，让你的 Agent 帮你安排参与时间和关注的内容。' : '复制活动信息，让你的 Agent 帮你安排交通、住宿与参会日程。' }}
+          </p>
+          <div class="export-preview" text-xs my-4 p-3 border border-gray-200 rounded-lg bg-white dark:border-gray-800 dark:bg-gray-900 aria-label="导出内容摘要">
+            <div class="preview-title" flex="~ items-center gap-1.5">
+              <div i-carbon-document-blank aria-hidden="true" /><span>{{ event.name }}</span><span class="file-format" font-mono ml-auto op60 shrink-0>.md</span>
+            </div>
+            <p mt-2 op60>
+              日期、地点、活动介绍及已收录的相关链接
+            </p>
+            <a :href="eventCanonicalUrl(event.id)" class="preview-source" mt-2 op60 underline underline-offset-2 inline-flex gap-1.5 items-center>附活动详情页来源链接 <div i-carbon-link aria-hidden="true" /></a>
+          </div>
+          <EventMarkdownButton :key="event.id" :event="event" variant="primary" />
+          <div class="secondary-actions" mt-4 flex="~ wrap gap-2">
+            <a :href="`/ics/${event.id}.ics`" download text-sm px-3 py-1.5 border border-gray-200 rounded-md inline-flex gap-1.5 transition items-center justify-center hover:text-teal-600 dark:border-gray-700 hover:border-teal-600><div i-carbon-calendar-add aria-hidden="true" /> 加入日历</a>
+            <EventShareButtons :key="event.id" :url="eventCanonicalUrl(event.id)" :title="event.name" />
           </div>
         </section>
-      </div>
-
-      <RelatedEvents v-if="related.length" :key="event.id" :events="related" class="event-related" />
-      <EventComments :event-id="event.id" class="event-discussion" />
+        <RelatedEvents v-if="related.length" :key="event.id" :events="related" class="event-related" />
+      </aside>
     </div>
-
     <div v-else mt-16 text-center op60>
       <div i-carbon-help text-4xl mx-auto mb-3 op50 />
       <p>活动不存在或已被移除。</p>
@@ -278,43 +299,180 @@ useHead(() => ({
 </template>
 
 <style scoped>
-.event-layout {
+.detail-page {
+  --detail-ink: var(--colors-gray-700);
+  --detail-line: var(--colors-gray-200);
+  --detail-surface: #fff;
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0 2rem 4rem;
+}
+html.dark .detail-page {
+  --detail-ink: var(--colors-gray-200);
+  --detail-line: var(--colors-gray-800);
+  --detail-surface: var(--colors-gray-900);
+}
+.site-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--detail-line);
+}
+.site-name {
+  display: block;
+  font-size: 1rem;
+  font-weight: 700;
+}
+.site-caption {
+  display: block;
+  font-size: 0.75rem;
+  opacity: 0.6;
+}
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  opacity: 0.6;
+  margin: 1.5rem 0;
+}
+.official-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.official-copy {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  min-width: 0;
+}
+.official-button {
+  min-width: 10rem;
+  min-height: 2.75rem;
+  flex-shrink: 0;
+}
+.preview-title > div {
+  flex-shrink: 0;
+}
+.preview-title > span:not(.file-format) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.secondary-actions > a,
+.secondary-actions :deep(button) {
+  flex: 1 1 auto;
+  width: auto;
+}
+.contribution-panel {
+  margin-top: 2rem;
+}
+.missing-description {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+.detail-page :is(button, a, [tabindex]):focus-visible {
+  outline: 2px solid var(--colors-teal-500);
+  outline-offset: 4px;
+}
+.hybrid-layout {
   display: grid;
-  grid-template-areas: 'content' 'discussion';
+  grid-template-columns: minmax(0, 1fr) 22rem;
   gap: 2rem;
+  align-items: start;
 }
-
-.event-layout.has-related {
-  grid-template-areas: 'content' 'related' 'discussion';
-}
-
-.event-content {
-  grid-area: content;
+.main-column,
+.side-column {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
   min-width: 0;
 }
-
-.event-related {
-  grid-area: related;
-  min-width: 0;
-}
-
+.overview-stack,
+.takeaway-panel,
+.supplemental-information,
+.event-related,
 .event-discussion {
-  grid-area: discussion;
   min-width: 0;
+}
+.supplemental-information > section:first-child {
   margin-top: 0;
 }
-
-@media (min-width: 1024px) {
-  .event-layout.has-related {
-    grid-template-columns: minmax(0, 1fr) 18rem;
-    grid-template-rows: min-content 1fr;
-    grid-template-areas: 'content related' 'discussion related';
-    column-gap: 3rem;
-    align-items: start;
+.event-discussion {
+  margin-top: 0;
+}
+.event-overview h1 {
+  overflow-wrap: anywhere;
+}
+.overview-description {
+  white-space: pre-line;
+  overflow-wrap: anywhere;
+}
+html.dark .event-overview .ev-title-themed {
+  color: color-mix(in srgb, var(--ev-c) 70%, white);
+}
+@media (max-width: 1023px) {
+  .hybrid-layout {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.5rem;
   }
-
+  .overview-stack,
+  .takeaway-panel,
+  .supplemental-information,
+  .event-related,
+  .event-discussion {
+    grid-column: 1;
+    grid-row: auto;
+  }
+  .main-column,
+  .side-column,
+  .supplemental-information {
+    display: contents;
+  }
+  .supplemental-information > section {
+    grid-column: 1;
+    order: 1;
+    margin-top: 0;
+    min-width: 0;
+  }
+  .takeaway-panel {
+    order: 2;
+  }
+  .supplemental-information > .contribution-panel {
+    order: 3;
+  }
   .event-related {
-    margin-top: 1rem;
+    order: 4;
+  }
+  .event-discussion {
+    order: 5;
+  }
+  .takeaway-panel > p {
+    margin-bottom: 1rem;
+  }
+}
+@media (max-width: 700px) {
+  .detail-page {
+    padding: 0 1.25rem 3rem;
+  }
+  .site-header {
+    padding: 1rem 0;
+  }
+  .back-link {
+    margin: 1.25rem 0;
+  }
+  .event-overview {
+    padding: 1.25rem;
+  }
+  .official-strip {
+    align-items: stretch;
+    flex-direction: column;
   }
 }
 </style>

--- a/src/router.ts
+++ b/src/router.ts
@@ -1,7 +1,12 @@
 import type { RouterScrollBehavior } from 'vue-router'
 
 /**
- * Keeps browser history navigation natural while ensuring every new page starts at the top.
+ * Restore browser history positions and keep existing detail/discussion links navigable.
  */
-export const scrollBehavior: RouterScrollBehavior = (_to, _from, savedPosition) =>
-  savedPosition ?? { top: 0 }
+export const scrollBehavior: RouterScrollBehavior = (to, _from, savedPosition) => {
+  if (savedPosition)
+    return savedPosition
+  if (to?.hash === '#comments' || to?.hash === '#details')
+    return { el: to.hash, top: 24 }
+  return { top: 0 }
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -13,6 +13,8 @@ export function formatDateRange(start: Date, end: Date): string {
     return fmtWithYear.format(start)
   if (start.getFullYear() === end.getFullYear() && start.getMonth() === end.getMonth())
     return `${fmtWithYear.format(start)} – ${end.getDate()}日`
+  if (start.getFullYear() !== end.getFullYear())
+    return `${fmtWithYear.format(start)} – ${fmtWithYear.format(end)}`
   return `${fmtWithYear.format(start)} – ${fmt.format(end)}`
 }
 

--- a/test/event-detail-c3.test.ts
+++ b/test/event-detail-c3.test.ts
@@ -1,0 +1,128 @@
+import { createHead } from '@unhead/vue/client'
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import EventMarkdownButton from '~/components/EventMarkdownButton.vue'
+import EventDetail from '~/pages/event/[id].vue'
+
+vi.mock('~/composables/dark', () => ({ isDark: ref(false), toggleDark: vi.fn() }))
+vi.mock('~/composables/events', async () => {
+  const { normalizeEvent } = await import('~/utils/events')
+  return {
+    allEvents: [
+      normalizeEvent({ id: 'online', name: 'Online community', startDate: '2099-10-10', city: '线上', format: 'online', url: 'https://example.com' }, 'online'),
+      normalizeEvent({ id: 'offline', name: 'A very long Vue community conference title '.repeat(5), startDate: '2099-10-10', city: '上海', tags: ['vue'], url: 'https://example.com' }, 'offline'),
+      normalizeEvent({ id: 'past', name: 'Past hybrid conference', startDate: '2020-12-31', endDate: '2021-01-02', city: '东京', country: '日本', format: 'hybrid', venue: 'Conference hall', organizer: 'Community', description: 'Conference description', url: 'https://example.com' }, 'past'),
+    ],
+  }
+})
+
+const wrappers: ReturnType<typeof mount>[] = []
+afterEach(() => wrappers.splice(0).forEach(wrapper => wrapper.unmount()))
+
+async function openEvent(path = '/event/offline') {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [{ path: '/', component: { template: '<div />' } }, { path: '/event/:id', name: '/event/[id]', component: EventDetail }],
+  })
+  await router.push(path)
+  await router.isReady()
+  const wrapper = mount(EventDetail, {
+    attachTo: document.body,
+    global: {
+      plugins: [router, createHead()],
+      stubs: { ContributionMenu: true, RelatedEvents: true, EventMapEmbed: true, EventShareButtons: true, EventComments: true },
+    },
+  })
+  wrappers.push(wrapper)
+  await flushPromises()
+  return { wrapper, router }
+}
+
+describe('hybrid event details', () => {
+  it('groups each desktop column independently so recommendations cannot stretch discussion spacing', async () => {
+    const { wrapper } = await openEvent()
+    expect(wrapper.get('.main-column').find('.contribution-panel').exists()).toBe(true)
+    expect(wrapper.get('.main-column').find('event-comments-stub').exists()).toBe(true)
+    expect(wrapper.get('.side-column').find('.takeaway-panel').exists()).toBe(true)
+    expect(wrapper.get('.side-column').find('.contribution-panel').exists()).toBe(false)
+  })
+
+  it('offers a discussion shortcut before the description in the overview', async () => {
+    const { wrapper } = await openEvent('/event/past')
+    const link = wrapper.get('.event-overview a[href="#comments"]')
+    expect(link.text()).toContain('查看讨论')
+    expect(link.element.compareDocumentPosition(wrapper.get('.overview-description').element) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('keeps saving visually secondary to official and contribution actions', async () => {
+    const { wrapper } = await openEvent()
+    for (const selector of ['.official-strip', '.contribution-panel'])
+      expect(wrapper.get(selector).classes()).toContain('action-panel')
+    expect(wrapper.get('.takeaway-panel').classes()).not.toContain('action-panel')
+    expect(wrapper.get('.takeaway-panel').classes()).toEqual(expect.arrayContaining(['bg-transparent', 'border-gray-200', 'dark:border-gray-800']))
+    expect(wrapper.get('.official-button').classes()).toContain('action-button')
+    expect(wrapper.getComponent(EventMarkdownButton).get('button').classes()).toContain('action-button')
+  })
+
+  it('shows details followed by discussion without tabs or hidden panels', async () => {
+    const { wrapper } = await openEvent()
+    expect(wrapper.find('[role="tablist"]').exists()).toBe(false)
+    expect(wrapper.find('[role="tabpanel"]').exists()).toBe(false)
+    expect(wrapper.get('.event-overview').isVisible()).toBe(true)
+    const comments = wrapper.get('event-comments-stub')
+    expect(comments.isVisible()).toBe(true)
+    expect(wrapper.get('#details').element.compareDocumentPosition(comments.element) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(wrapper.getComponent(EventMarkdownButton).isVisible()).toBe(true)
+    expect(wrapper.get('.contribution-panel').isVisible()).toBe(true)
+  })
+
+  it('keeps details visible for discussion links and updates comments on event navigation', async () => {
+    const { wrapper, router } = await openEvent('/event/offline.html#comments')
+    expect(wrapper.get('.event-overview').isVisible()).toBe(true)
+    expect(wrapper.get('event-comments-stub').isVisible()).toBe(true)
+    await router.push('/event/online')
+    await flushPromises()
+    expect(wrapper.get('.event-overview').isVisible()).toBe(true)
+    expect(wrapper.get('event-comments-stub').attributes('eventid')).toBe('online')
+  })
+
+  it('handles online-only events without inventing travel details or recommendations', async () => {
+    const { wrapper } = await openEvent('/event/online')
+    expect(wrapper.get('.event-overview').text()).toContain('线上参与')
+    expect(wrapper.get('.takeaway-panel').text()).toContain('安排参与时间')
+    expect(wrapper.get('.takeaway-panel').text()).not.toContain('住宿')
+    expect(wrapper.find('a[href*="amap"]').exists()).toBe(false)
+    expect(wrapper.find('related-events-stub').exists()).toBe(false)
+    expect(wrapper.find('.past-label').exists()).toBe(false)
+  })
+
+  it('keeps full titles and theme icons while offering missing-data contributions', async () => {
+    const { wrapper } = await openEvent()
+    expect(wrapper.get('h1').text()).toBe('A very long Vue community conference title '.repeat(5).trim())
+    expect(wrapper.get('.event-overview').classes()).toContain('ev-themed')
+    expect(wrapper.get('.event-overview .ev-watermark').attributes('aria-hidden')).toBe('true')
+    expect(wrapper.get('.event-overview').text()).toContain('具体场馆待补充')
+    expect(wrapper.find('a[href*="amap"]').exists()).toBe(false)
+    expect(wrapper.get('.missing-description contribution-menu-stub').attributes('label')).toBe('补充介绍')
+  })
+
+  it('uses historical wording, full years and country details for past hybrid events', async () => {
+    const { wrapper } = await openEvent('/event/past')
+    expect(wrapper.get('.past-label').text()).toBe('已结束')
+    expect(wrapper.get('.official-strip').text()).toContain('回顾这场活动')
+    expect(wrapper.get('.takeaway-panel').text()).toContain('整理资料')
+    expect(wrapper.get('.event-overview').text()).toContain('2020年12月31日 – 2021年1月2日')
+    expect(wrapper.get('.event-overview').text()).toContain('东京 · 日本')
+    expect(wrapper.get('.format-label').text()).toBe('线上+线下')
+    expect(wrapper.find('a[href*="amap"]').exists()).toBe(true)
+  })
+
+  it('omits event actions and discussion for an unknown event', async () => {
+    const { wrapper } = await openEvent('/event/missing')
+    expect(wrapper.text()).toContain('活动不存在或已被移除')
+    expect(wrapper.find('event-comments-stub').exists()).toBe(false)
+    expect(wrapper.findComponent(EventMarkdownButton).exists()).toBe(false)
+  })
+})

--- a/test/event-detail-markdown.test.ts
+++ b/test/event-detail-markdown.test.ts
@@ -47,7 +47,7 @@ describe('event detail Markdown integration', () => {
         await flushPromises()
         const event = allEvents.find(event => event.id === id)!
         expect(wrapper.get('h1').text()).toBe(event.name)
-        expect(wrapper.get('a[href="#comments"]').text()).toContain('查看讨论')
+        expect(wrapper.get('#comments').isVisible()).toBe(true)
         expect(wrapper.getComponent(EventComments).props('eventId')).toBe(id)
         expect(wrapper.get('[data-testid="giscus"]').attributes('term')).toBe(`event:${id}`)
         await wrapper.getComponent(EventMarkdownButton).get('button').trigger('click')

--- a/test/event-detail-theme.test.ts
+++ b/test/event-detail-theme.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs'
+import { compileStyle, parse } from '@vue/compiler-sfc'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const { descriptor } = parse(readFileSync(`${process.cwd()}/src/pages/event/[id].vue`, 'utf8'))
+const compiled = compileStyle({ source: descriptor.styles[0]!.content, filename: 'event-detail.vue', id: 'data-v-theme-test', scoped: true })
+
+afterEach(() => {
+  document.documentElement.classList.remove('dark')
+  document.head.innerHTML = ''
+  document.body.innerHTML = ''
+})
+
+/** Exercise the compiled scoped selectors against the real html-level theme switch. */
+function mountStyles(dark: boolean) {
+  document.documentElement.classList.toggle('dark', dark)
+  const style = document.createElement('style')
+  style.textContent = compiled.code
+  document.head.append(style)
+  document.body.innerHTML = '<div class="detail-page" data-v-theme-test></div>'
+  return getComputedStyle(document.querySelector('.detail-page')!)
+}
+
+describe('event detail theme integration', () => {
+  it('inherits the shared dark palette through the html theme switch', () => {
+    const style = mountStyles(true)
+    expect(style.getPropertyValue('--detail-surface').trim()).toBe('var(--colors-gray-900)')
+    expect(style.getPropertyValue('--detail-ink').trim()).toBe('var(--colors-gray-200)')
+    expect(style.getPropertyValue('--detail-line').trim()).toBe('var(--colors-gray-800)')
+  })
+
+  it('keeps the approved light surfaces when dark mode is off', () => {
+    const style = mountStyles(false)
+    expect(style.getPropertyValue('--detail-surface').trim()).toBe('#fff')
+    expect(style.getPropertyValue('--detail-ink').trim()).toBe('var(--colors-gray-700)')
+  })
+})

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { parseDay } from '~/utils/events'
+import { formatDateRange } from '~/utils/format'
+
+describe('formatDateRange', () => {
+  it('retains both years for trips crossing a year boundary', () => {
+    expect(formatDateRange(parseDay('2026-12-31'), parseDay('2027-01-02')))
+      .toBe('2026年12月31日 – 2027年1月2日')
+  })
+
+  it('keeps single-day and same-month ranges compact', () => {
+    expect(formatDateRange(parseDay('2026-09-22'), parseDay('2026-09-22'))).toBe('2026年9月22日')
+    expect(formatDateRange(parseDay('2026-09-22'), parseDay('2026-09-24'))).toBe('2026年9月22日 – 24日')
+  })
+})

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -13,4 +13,12 @@ describe('scrollBehavior', () => {
 
     expect(scrollBehavior(route, route, savedPosition)).toBe(savedPosition)
   })
+
+  it('scrolls detail and discussion links to their sections', () => {
+    const details = { path: '/event/vueconf', hash: '#details' } as never
+    const discussion = { path: '/event/vueconf', hash: '#comments' } as never
+    expect(scrollBehavior(discussion, details, null)).toEqual({ el: '#comments', top: 24 })
+    expect(scrollBehavior(details, discussion, null)).toEqual({ el: '#details', top: 24 })
+    expect(scrollBehavior(discussion, route, null)).toEqual({ el: '#comments', top: 24 })
+  })
 })

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -8,6 +8,8 @@ import {
 
 export default defineConfig({
   shortcuts: [
+    ['action-panel', 'p-5 border border-teal-200 rounded-xl bg-teal-50/60 dark:border-teal-900 dark:bg-teal-950/25'],
+    ['action-button', 'text-sm text-white px-3 py-2 rounded-md bg-teal-600 inline-flex gap-1.5 transition items-center justify-center hover:bg-teal-700'],
     ['icon-btn', 'inline-flex items-center justify-center text-lg op75 hover:op100 hover:text-teal-600 transition cursor-pointer select-none'],
     ['chip', 'inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-sm border border-gray-200 dark:border-gray-700 select-none cursor-pointer transition'],
     ['chip-active', 'bg-teal-600 border-teal-600 text-white hover:bg-teal-700'],


### PR DESCRIPTION
## What this PR changes

- [x] Other (feature / UI improvement)

Event details keep the compact overview with dates, location, organizer, description, and existing brand icons. A separate official-site card sits directly below it, with a wider primary button. A discussion shortcut appears before the description.

On desktop, the saving/sharing panel sits above related events in an independent sidebar. Its transparent background and gray border match the location panel. Each column flows independently to avoid extra vertical gaps caused by content in the other column.

On mobile, the order is overview and official-site action, location and related links, saving/sharing, community contribution, related-event carousel, then comments. The Markdown preview remains visible on both screen sizes.

The implementation reuses EventCard, EventShareButtons, EventComments, ContributionMenu, and the existing icon system. Shared panel and primary-button styles follow the existing contribution UI in both themes. Online/past events, missing information, long titles, unknown event IDs, and cross-year dates are covered.

## Validation

- [x] `pnpm run lint --fix`
- [x] `pnpm run typecheck`
- [x] 87 tests pass
- [x] Production build and prerendering
- [x] Desktop and mobile visual checks, light/dark themes, copy feedback, focus states, and discussion links
- [x] Imported files verified identical to the final preview served on port 60087

This branch starts from the master commit that reverts #37. No event-data changes.
