### PR TITLE
fix: keep calendar previews open across the pointer gap

### DIFF
--- a/components.d.ts
+++ b/components.d.ts
@@ -11,6 +11,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    CalendarEventPopover: typeof import('./src/components/CalendarEventPopover.vue')['default']
     CalendarView: typeof import('./src/components/CalendarView.vue')['default']
     ContributionMenu: typeof import('./src/components/ContributionMenu.vue')['default']
     EventCard: typeof import('./src/components/EventCard.vue')['default']

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@unhead/vue": "catalog:frontend",
     "@vueuse/core": "catalog:frontend",
     "leaflet": "catalog:frontend",
+    "reka-ui": "catalog:frontend",
     "vue": "catalog:frontend",
     "vue-router": "catalog:frontend"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ catalogs:
     leaflet:
       specifier: ^1.9.4
       version: 1.9.4
+    reka-ui:
+      specifier: ^2.10.4
+      version: 2.10.4
     vue:
       specifier: ^3.5.29
       version: 3.5.29
@@ -131,6 +134,9 @@ importers:
       leaflet:
         specifier: catalog:frontend
         version: 1.9.4
+      reka-ui:
+        specifier: catalog:frontend
+        version: 2.10.4(vue@3.5.29(typescript@5.9.3))
       vue:
         specifier: catalog:frontend
         version: 3.5.29(typescript@5.9.3)
@@ -227,32 +233,6 @@ importers:
         version: 3.2.5(typescript@5.9.3)
 
 packages:
-
-  '@giscus/vue@3.1.1':
-    resolution: {integrity: sha512-xgsc93MibRQ0d1glBxN1BrEREHTIf3BPYs/3R+UZHNqawFFoWBV6iJ7uVCXMqoEKZdE2c78B3aKt5gfGqo8I5A==}
-    peerDependencies:
-      vue: '>=3.2.0'
-
-  '@lit-labs/ssr-dom-shim@1.6.0':
-    resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
-
-  '@lit/reactive-element@2.1.2':
-    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
-
-  '@types/trusted-types@2.0.7':
-    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
-
-  giscus@1.6.0:
-    resolution: {integrity: sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==}
-
-  lit-element@4.2.2:
-    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
-
-  lit-html@3.3.3:
-    resolution: {integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==}
-
-  lit@3.3.3:
-    resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
   '@aashutoshrathi/word-wrap@1.2.6':
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
@@ -837,6 +817,23 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@floating-ui/vue@1.1.11':
+    resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
+
+  '@giscus/vue@3.1.1':
+    resolution: {integrity: sha512-xgsc93MibRQ0d1glBxN1BrEREHTIf3BPYs/3R+UZHNqawFFoWBV6iJ7uVCXMqoEKZdE2c78B3aKt5gfGqo8I5A==}
+    peerDependencies:
+      vue: '>=3.2.0'
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -875,6 +872,12 @@ packages:
   '@iconify/utils@3.1.0':
     resolution: {integrity: sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==}
 
+  '@internationalized/date@3.12.4':
+    resolution: {integrity: sha512-M1dEn4c1U1HsSlaVR8upZtSqvXrTkHDfv18H01uCSJyjVLDxnBR38v/fMxecmlwXKR4i9HeZcmgQAPE6A+aGJQ==}
+
+  '@internationalized/number@3.6.8':
+    resolution: {integrity: sha512-8UmMFia46DUt+k97zKd9fKWXcWHR+k8ae3eYzILETuT2KbIvLyOfac7zesw+sJdRAAZ7Q9pM1Mk22aXp2LD0Ig==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -907,6 +910,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lit-labs/ssr-dom-shim@1.6.0':
+    resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
+
+  '@lit/reactive-element@2.1.2':
+    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
 
   '@napi-rs/wasm-runtime@0.2.10':
     resolution: {integrity: sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ==}
@@ -1352,6 +1361,17 @@ packages:
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
 
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
+  '@tanstack/virtual-core@3.17.10':
+    resolution: {integrity: sha512-eMorKWIi2nekElu+8DgSMJR4iR+sTDeh+W8VjKiMH79yUfEDJ3W9aL/96/wwbxNjyV6EfN39HKszSxjd90zAqQ==}
+
+  '@tanstack/vue-virtual@3.13.38':
+    resolution: {integrity: sha512-9GE1RY5EBmA5w+0AR7AIL940EnGKik7o69QLDDcZg2sBLbitkjFRUD1BKxgKPD6WsCS/ptOPndARtDTkShH1jA==}
+    peerDependencies:
+      vue: ^2.7.0 || ^3.0.0
+
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
@@ -1390,6 +1410,9 @@ packages:
 
   '@types/node@25.3.3':
     resolution: {integrity: sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -1979,6 +2002,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   ast-kit@1.4.2:
     resolution: {integrity: sha512-lvGehj1XsrIoQrD5CfPduIzQbcpuX2EPjlk/vDMDQF9U9HLRB6WwMTdighj5n52hdhh8xg9VgPTU7Q25MuJ/rw==}
     engines: {node: '>=16.14.0'}
@@ -2210,6 +2237,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2620,6 +2650,9 @@ packages:
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
+  giscus@1.6.0:
+    resolution: {integrity: sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ==}
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
@@ -2830,6 +2863,15 @@ packages:
   listr2@9.0.5:
     resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
     engines: {node: '>=20.0.0'}
+
+  lit-element@4.2.2:
+    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
+
+  lit-html@3.3.3:
+    resolution: {integrity: sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==}
+
+  lit@3.3.3:
+    resolution: {integrity: sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==}
 
   local-pkg@1.1.1:
     resolution: {integrity: sha512-WunYko2W1NcdfAFpuLUoucsgULmgDBRkdxHxWQ7mK0cQqwPiy8E1enjuRBrhLtZkB5iScJ1XIPdhVEFK8aOLSg==}
@@ -3267,6 +3309,11 @@ packages:
   regjsparser@0.13.0:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
+
+  reka-ui@2.10.4:
+    resolution: {integrity: sha512-kbS5GAbkHkYj0EVKAg5ZPEPndhBjeUFSa1Aq5m5ftQwyHnB1v5tw8X6fcwfKH/ry3StPXblMWM1DW82MVS71cw==}
+    peerDependencies:
+      vue: '>= 3.4.0'
 
   relateurl@0.2.7:
     resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
@@ -3763,6 +3810,17 @@ packages:
   vue-component-type-helpers@2.0.13:
     resolution: {integrity: sha512-xNO5B7DstNWETnoYflLkVgh8dK8h2ZDgxY1M2O0zrqGeBNq5yAZ8a10yCS9+HnixouNGYNX+ggU9MQQq86HTpg==}
 
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
   vue-eslint-parser@10.4.0:
     resolution: {integrity: sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3877,39 +3935,6 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-
-  '@giscus/vue@3.1.1(vue@3.5.29(typescript@5.9.3))':
-    dependencies:
-      giscus: 1.6.0
-      vue: 3.5.29(typescript@5.9.3)
-
-  '@lit-labs/ssr-dom-shim@1.6.0': {}
-
-  '@lit/reactive-element@2.1.2':
-    dependencies:
-      '@lit-labs/ssr-dom-shim': 1.6.0
-
-  '@types/trusted-types@2.0.7': {}
-
-  giscus@1.6.0:
-    dependencies:
-      lit: 3.3.3
-
-  lit-element@4.2.2:
-    dependencies:
-      '@lit-labs/ssr-dom-shim': 1.6.0
-      '@lit/reactive-element': 2.1.2
-      lit-html: 3.3.3
-
-  lit-html@3.3.3:
-    dependencies:
-      '@types/trusted-types': 2.0.7
-
-  lit@3.3.3:
-    dependencies:
-      '@lit/reactive-element': 2.1.2
-      lit-element: 4.2.2
-      lit-html: 3.3.3
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
@@ -4350,6 +4375,31 @@ snapshots:
 
   '@exodus/bytes@1.14.1': {}
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/utils@0.2.12': {}
+
+  '@floating-ui/vue@1.1.11(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@floating-ui/utils': 0.2.12
+      vue-demi: 0.14.10(vue@3.5.29(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@giscus/vue@3.1.1(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      giscus: 1.6.0
+      vue: 3.5.29(typescript@5.9.3)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -4386,6 +4436,14 @@ snapshots:
       '@antfu/install-pkg': 1.1.0
       '@iconify/types': 2.0.0
       mlly: 1.8.0
+
+  '@internationalized/date@3.12.4':
+    dependencies:
+      '@swc/helpers': 0.5.23
+
+  '@internationalized/number@3.6.8':
+    dependencies:
+      '@swc/helpers': 0.5.23
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4425,6 +4483,12 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lit-labs/ssr-dom-shim@1.6.0': {}
+
+  '@lit/reactive-element@2.1.2':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
 
   '@napi-rs/wasm-runtime@0.2.10':
     dependencies:
@@ -4688,6 +4752,17 @@ snapshots:
       estraverse: 5.3.0
       picomatch: 4.0.3
 
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tanstack/virtual-core@3.17.10': {}
+
+  '@tanstack/vue-virtual@3.13.38(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.10
+      vue: 3.5.29(typescript@5.9.3)
+
   '@tybys/wasm-util@0.9.0':
     dependencies:
       tslib: 2.8.1
@@ -4726,6 +4801,8 @@ snapshots:
   '@types/node@25.3.3':
     dependencies:
       undici-types: 7.18.2
+
+  '@types/trusted-types@2.0.7': {}
 
   '@types/unist@3.0.3': {}
 
@@ -5576,6 +5653,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   ast-kit@1.4.2:
     dependencies:
       '@babel/parser': 7.27.5
@@ -5771,6 +5852,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   defu@6.1.4: {}
+
+  defu@6.1.7: {}
 
   dequal@2.0.3: {}
 
@@ -6274,6 +6357,10 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  giscus@1.6.0:
+    dependencies:
+      lit: 3.3.3
+
   github-slugger@2.0.0: {}
 
   glob-parent@6.0.2:
@@ -6484,6 +6571,22 @@ snapshots:
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.0
+
+  lit-element@4.2.2:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.6.0
+      '@lit/reactive-element': 2.1.2
+      lit-html: 3.3.3
+
+  lit-html@3.3.3:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@3.3.3:
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit-element: 4.2.2
+      lit-html: 3.3.3
 
   local-pkg@1.1.1:
     dependencies:
@@ -7128,6 +7231,22 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  reka-ui@2.10.4(vue@3.5.29(typescript@5.9.3)):
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@floating-ui/vue': 1.1.11(vue@3.5.29(typescript@5.9.3))
+      '@internationalized/date': 3.12.4
+      '@internationalized/number': 3.6.8
+      '@tanstack/vue-virtual': 3.13.38(vue@3.5.29(typescript@5.9.3))
+      '@vueuse/core': 14.2.1(vue@3.5.29(typescript@5.9.3))
+      '@vueuse/shared': 14.2.1(vue@3.5.29(typescript@5.9.3))
+      aria-hidden: 1.2.6
+      defu: 6.1.7
+      ohash: 2.0.11
+      vue: 3.5.29(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+
   relateurl@0.2.7: {}
 
   require-from-string@2.0.2: {}
@@ -7688,6 +7807,10 @@ snapshots:
   vscode-uri@3.0.8: {}
 
   vue-component-type-helpers@2.0.13: {}
+
+  vue-demi@0.14.10(vue@3.5.29(typescript@5.9.3)):
+    dependencies:
+      vue: 3.5.29(typescript@5.9.3)
 
   vue-eslint-parser@10.4.0(eslint@10.0.2(jiti@2.6.1)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ catalogs:
     '@unhead/vue': ^2.1.16
     '@vueuse/core': ^14.2.1
     leaflet: ^1.9.4
+    reka-ui: ^2.10.4
     vue: ^3.5.29
     vue-router: ^5.0.3
 onlyBuiltDependencies:

--- a/scripts/check-calendar-popover.mjs
+++ b/scripts/check-calendar-popover.mjs
@@ -1,0 +1,99 @@
+/** Run against `pnpm dev`: node scripts/check-calendar-popover.mjs [url]. Requires agent-browser on PATH. */
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import process from 'node:process'
+
+const session = `calendar-regression-${process.pid}`
+const trigger = 'button[title="华为全联接大会 2026 (HUAWEI CONNECT 2026)"]'
+const popup = '.calendar-event-popover'
+function browser(...args) {
+  const result = JSON.parse(execFileSync('agent-browser', ['--session', session, '--json', ...args.map(String)], { encoding: 'utf8' }))
+  assert.ok(result.success, result.error)
+  return result.data
+}
+function evaluate(code) {
+  return browser('eval', code).result
+}
+function visible() {
+  return evaluate(`!!document.querySelector('${popup}')`)
+}
+function bounds(selector) {
+  return evaluate(`document.querySelector(${JSON.stringify(selector)}).getBoundingClientRect().toJSON()`)
+}
+try {
+  browser('open', process.argv[2] ?? 'http://localhost:60086')
+  browser('wait', 'input[type="search"]')
+  browser('fill', 'input[type="search"]', 'HUAWEI CONNECT')
+  browser('find', 'role', 'button', 'click', '--name', '日历', '--exact')
+  browser('wait', trigger)
+  for (const height of [1400, 720]) {
+    browser('set', 'viewport', 1280, height)
+    browser('mouse', 'move', 10, 10)
+    browser('hover', trigger)
+    browser('wait', popup)
+    const anchor = bounds(trigger)
+    const content = bounds(popup)
+    const side = evaluate(`document.querySelector('${popup}').dataset.side`)
+    const x = Math.round(Math.max(anchor.left, content.left) + 20)
+    const y = side === 'bottom' ? anchor.bottom + 3 : anchor.top - 3
+    browser('mouse', 'move', x, side === 'bottom' ? anchor.bottom - 1 : anchor.top + 1)
+    browser('mouse', 'move', x, y)
+    browser('wait', 500)
+    assert.ok(visible(), 'Card must stay open while the pointer pauses in the visual gap')
+    assert.ok(content.top >= 0 && content.bottom <= height, 'Card must fit the viewport')
+    assert.ok(content.bottom <= anchor.top + 1 || content.top >= anchor.bottom - 1, 'Card must not overlap its trigger')
+    browser('hover', `${popup} a:first-child`)
+    browser('wait', 300)
+    assert.ok(visible(), 'Card actions must remain reachable from the gap')
+    browser('mouse', 'move', 10, 10)
+    browser('wait', 300)
+    assert.ok(!visible(), 'Leaving the card must dismiss a hover preview')
+  }
+  browser('focus', trigger)
+  browser('press', 'Enter')
+  browser('wait', popup)
+  assert.ok(evaluate(`document.querySelector('${popup}').contains(document.activeElement)`), 'Keyboard opening must focus a card action')
+  browser('press', 'Escape')
+  assert.ok(!visible(), 'Escape must dismiss the card')
+  assert.ok(evaluate(`document.activeElement.matches(${JSON.stringify(trigger)})`), 'Escape must return keyboard focus to the trigger')
+  browser('set', 'device', 'iPhone 15')
+  // agent-browser's device preset changes size/UA; enable actual touch media too.
+  const socket = new WebSocket(browser('get', 'cdp-url').cdpUrl)
+  await new Promise(resolve => socket.addEventListener('open', resolve, { once: true }))
+  let messageId = 0
+  async function cdp(method, params = {}, sessionId) {
+    const id = ++messageId
+    const response = new Promise((resolve, reject) => {
+      function receive(event) {
+        const data = JSON.parse(event.data)
+        if (data.id !== id)
+          return
+        socket.removeEventListener('message', receive)
+        if (data.error)
+          reject(new Error(data.error.message))
+        else
+          resolve(data.result)
+      }
+      socket.addEventListener('message', receive)
+    })
+    socket.send(JSON.stringify({ id, method, params, sessionId }))
+    return response
+  }
+  const { targetInfos } = await cdp('Target.getTargets')
+  const target = targetInfos.find(target => target.type === 'page' && target.url === browser('get', 'url').url)
+  const { sessionId } = await cdp('Target.attachToTarget', { targetId: target.targetId, flatten: true })
+  await cdp('Emulation.setTouchEmulationEnabled', { enabled: true, maxTouchPoints: 1 }, sessionId)
+  assert.ok(!evaluate('matchMedia("(hover: hover) and (pointer: fine)").matches'), 'Touch media must be enabled')
+  browser('reload')
+  browser('wait', trigger)
+  browser('click', trigger)
+  browser('wait', '.rounded-t-2xl')
+  assert.ok(!visible(), 'Touch must retain the bottom sheet')
+  browser('click', 'button[title="关闭"]')
+  assert.ok(!evaluate('!!document.querySelector(".rounded-t-2xl")'), 'Touch sheet must close')
+  socket.close()
+  console.log('PASS: hover gap, viewport bounds, actions, dismissal, keyboard focus, and touch sheet')
+}
+finally {
+  browser('close')
+}

--- a/src/components/CalendarEventPopover.vue
+++ b/src/components/CalendarEventPopover.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import type { NormalizedEvent } from '~/types'
+import { PopoverContent, PopoverPortal, PopoverRoot, PopoverTrigger } from 'reka-ui'
+
+const { event, canHover, open } = defineProps<{
+  event: NormalizedEvent
+  canHover: boolean
+  open: boolean
+}>()
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  'select': []
+}>()
+
+const openedByHover = ref(false)
+let closeTimer: ReturnType<typeof setTimeout> | undefined
+
+function cancelClose() {
+  clearTimeout(closeTimer)
+}
+
+function enter(event: PointerEvent) {
+  cancelClose()
+  if (!canHover || event.pointerType === 'touch' || open)
+    return
+  openedByHover.value = true
+  emit('update:open', true)
+}
+
+function leave() {
+  if (openedByHover.value) {
+    cancelClose()
+    closeTimer = setTimeout(() => emit('update:open', false), 140)
+  }
+}
+
+function updateOpen(value: boolean) {
+  cancelClose()
+  if (canHover)
+    emit('update:open', value)
+}
+
+function click() {
+  openedByHover.value = false
+  if (!canHover)
+    emit('select')
+}
+
+watch(() => open, cancelClose)
+onBeforeUnmount(cancelClose)
+</script>
+
+<template>
+  <PopoverRoot :open="canHover && open" @update:open="updateOpen">
+    <PopoverTrigger as-child @pointerenter="enter" @pointerleave="leave" @click="click">
+      <slot />
+    </PopoverTrigger>
+    <PopoverPortal>
+      <PopoverContent
+        side="bottom"
+        align="start"
+        :collision-padding="8"
+        class="calendar-event-popover py-1.5 w-72 z-50"
+        :aria-label="event.name"
+        @pointerenter="cancelClose"
+        @pointerleave="leave"
+        @focusin="openedByHover = false"
+        @open-auto-focus="openedByHover && $event.preventDefault()"
+        @close-auto-focus="openedByHover && $event.preventDefault()"
+      >
+        <div class="calendar-event-popover-card text-gray-700 p-4 card shadow-xl overflow-auto dark:text-gray-200">
+          <EventDetailCard :event="event" />
+        </div>
+      </PopoverContent>
+    </PopoverPortal>
+  </PopoverRoot>
+</template>
+
+<style scoped>
+/* Padding belongs to the hit area, so pausing in the visual gap stays open. */
+.calendar-event-popover {
+  max-width: calc(100vw - 16px);
+}
+
+.calendar-event-popover-card {
+  max-height: calc(var(--reka-popover-content-available-height) - 12px);
+}
+</style>

--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -49,59 +49,14 @@ function goToday() {
 
 // --- detail popover ---
 const selected = ref<NormalizedEvent | null>(null)
-const anchor = ref<DOMRect | null>(null)
-let closeTimer: ReturnType<typeof setTimeout> | undefined
-
-function open(event: NormalizedEvent, el: EventTarget | null) {
-  if (!(el instanceof HTMLElement))
-    return
-  clearTimeout(closeTimer)
-  anchor.value = el.getBoundingClientRect()
-  selected.value = event
-}
+const activeSegment = ref<string | null>(null)
 
 function close() {
-  clearTimeout(closeTimer)
   selected.value = null
+  activeSegment.value = null
 }
 
-function cancelClose() {
-  clearTimeout(closeTimer)
-}
-
-/** Small grace period so the pointer can travel from the chip into the card. */
-function scheduleClose() {
-  if (canHover.value)
-    closeTimer = setTimeout(() => (selected.value = null), 140)
-}
-
-function onChipEnter(event: NormalizedEvent, el: EventTarget | null) {
-  if (canHover.value)
-    open(event, el)
-}
-
-function onChipClick(event: NormalizedEvent, el: EventTarget | null) {
-  if (selected.value === event)
-    close()
-  else
-    open(event, el)
-}
-
-/** Desktop card position, anchored to the chip and clamped to the viewport. */
-const floatStyle = computed(() => {
-  if (!canHover.value || !anchor.value)
-    return undefined
-  const width = 288
-  const margin = 8
-  const estHeight = 240
-  const left = Math.max(margin, Math.min(anchor.value.left, window.innerWidth - width - margin))
-  const below = anchor.value.bottom + 6
-  const flip = below + estHeight > window.innerHeight
-  const top = flip ? Math.max(margin, anchor.value.top - estHeight - 6) : below
-  return { left: `${left}px`, top: `${top}px`, width: `${width}px` }
-})
-
-watch(cursor, close)
+watch([cursor, canHover], close)
 </script>
 
 <template>
@@ -173,39 +128,44 @@ watch(cursor, close)
             </div>
           </div>
 
-          <button
+          <CalendarEventPopover
             v-for="seg in week.segments"
             :key="seg.event.id + seg.startCol"
-            type="button"
-            class="text-[10px] leading-4.5 mx-0.5 px-1 text-left block truncate transition sm:text-xs sm:leading-5"
-            :class="[
-              themeById.get(seg.event.id)
-                ? (selected === seg.event ? 'ev-bar ev-bar-selected' : 'ev-bar')
-                : (selected === seg.event
-                  ? 'bg-teal-600 text-white'
-                  : 'bg-teal-50 text-teal-800 hover:bg-teal-100 dark:bg-teal-900/40 dark:text-teal-200 dark:hover:bg-teal-900/70'),
-              seg.continuesLeft ? 'rounded-l-none' : 'rounded-l',
-              seg.continuesRight ? 'rounded-r-none' : 'rounded-r',
-            ]"
-            :style="{
-              'gridColumn': `${seg.startCol + 1} / span ${seg.span}`,
-              'gridRow': seg.lane + 2,
-              '--ev-color': themeById.get(seg.event.id)?.primary.color,
-              '--ev-color-dark': themeById.get(seg.event.id)?.primary.colorDark
-                ?? themeById.get(seg.event.id)?.primary.color,
-            }"
-            :title="seg.event.name"
-            @mouseenter="onChipEnter(seg.event, $event.currentTarget)"
-            @mouseleave="scheduleClose()"
-            @click="onChipClick(seg.event, $event.currentTarget)"
+            :event="seg.event"
+            :can-hover="canHover"
+            :open="activeSegment === `${w}:${seg.event.id}:${seg.startCol}`"
+            @update:open="activeSegment = $event ? `${w}:${seg.event.id}:${seg.startCol}` : null"
+            @select="selected = selected === seg.event ? null : seg.event"
           >
-            <div
-              v-if="themeById.get(seg.event.id) && !seg.continuesLeft"
-              :class="themeById.get(seg.event.id)!.primary.icon"
-              class="text-[11px] mr-0.5 align-[-2px] inline-block sm:text-xs"
-            />
-            {{ seg.continuesLeft ? '◂ ' : '' }}{{ seg.event.name }}
-          </button>
+            <button
+              type="button"
+              class="text-[10px] leading-4.5 mx-0.5 px-1 text-left block truncate transition sm:text-xs sm:leading-5"
+              :class="[
+                themeById.get(seg.event.id)
+                  ? (activeSegment === `${w}:${seg.event.id}:${seg.startCol}` || selected === seg.event ? 'ev-bar ev-bar-selected' : 'ev-bar')
+                  : (activeSegment === `${w}:${seg.event.id}:${seg.startCol}` || selected === seg.event
+                    ? 'bg-teal-600 text-white'
+                    : 'bg-teal-50 text-teal-800 hover:bg-teal-100 dark:bg-teal-900/40 dark:text-teal-200 dark:hover:bg-teal-900/70'),
+                seg.continuesLeft ? 'rounded-l-none' : 'rounded-l',
+                seg.continuesRight ? 'rounded-r-none' : 'rounded-r',
+              ]"
+              :style="{
+                'gridColumn': `${seg.startCol + 1} / span ${seg.span}`,
+                'gridRow': seg.lane + 2,
+                '--ev-color': themeById.get(seg.event.id)?.primary.color,
+                '--ev-color-dark': themeById.get(seg.event.id)?.primary.colorDark
+                  ?? themeById.get(seg.event.id)?.primary.color,
+              }"
+              :title="seg.event.name"
+            >
+              <div
+                v-if="themeById.get(seg.event.id) && !seg.continuesLeft"
+                :class="themeById.get(seg.event.id)!.primary.icon"
+                class="text-[11px] mr-0.5 align-[-2px] inline-block sm:text-xs"
+              />
+              {{ seg.continuesLeft ? '◂ ' : '' }}{{ seg.event.name }}
+            </button>
+          </CalendarEventPopover>
         </div>
       </div>
     </div>
@@ -222,16 +182,6 @@ watch(cursor, close)
           <EventDetailCard :event="selected" />
         </div>
       </template>
-
-      <div
-        v-else-if="selected && canHover"
-        class="text-gray-700 p-4 card shadow-xl fixed z-50 dark:text-gray-200"
-        :style="floatStyle"
-        @mouseenter="cancelClose()"
-        @mouseleave="scheduleClose()"
-      >
-        <EventDetailCard :event="selected" />
-      </div>
     </Teleport>
   </div>
 </template>


### PR DESCRIPTION
Calendar previews disappear when the pointer pauses in the 6px gap between an event bar and its card. The estimated 240px card height also makes taller previews overlap their trigger when flipped above it.

Use Reka UI Popover for measured positioning, collision handling, focus, and dismissal. Keep the visual gap inside the popover's pointer hit area, preserve the touch bottom sheet, and track individual calendar segments so multi-week events anchor to the hovered segment. Popover keeps the detail and official-site links keyboard accessible.

Validation: `pnpm test --run` (87 tests), `pnpm lint`, `pnpm typecheck`, and `pnpm build` passed. `node scripts/check-calendar-popover.mjs` passed against the local app using agent-browser: gap dwell, card actions, viewport bounds, hover dismissal, keyboard focus/Escape, and actual touch emulation. The gap failure was reproduced on the deployed site before the change.

## Visual changes

Captured with Vishot using matching scenarios, viewport, theme, locale, and a fixed date (2026-09-13). Before: `a7219d4`. After: `d2d149e`.

The cyan marker identifies the pointer paused in the 6px gap for 500ms.

| Before | After |
|---|---|
| ![Before: Calendar / pointer paused in the 6px gap](https://github.com/user-attachments/assets/7c32df50-51f5-46cf-9021-ab307af5e086) | ![After: Calendar / pointer paused in the 6px gap](https://github.com/user-attachments/assets/6ac3b63f-a687-40de-8e04-4632f6545d23) |
| Calendar / pointer paused in the 6px gap | Calendar / pointer paused in the 6px gap |
| ![Before: Calendar / constrained viewport and upward placement](https://github.com/user-attachments/assets/9aca651e-0dd6-4ce7-b3a6-3def81766fab) | ![After: Calendar / constrained viewport and upward placement](https://github.com/user-attachments/assets/c8f20c76-946b-4bde-94f7-7f7868af8e7c) |
| Calendar / constrained viewport and upward placement | Calendar / constrained viewport and upward placement |
| ![Before: Calendar / touch bottom sheet (preserved)](https://github.com/user-attachments/assets/f79ba73b-aba7-4fe3-afeb-c07831685210) | ![After: Calendar / touch bottom sheet (preserved)](https://github.com/user-attachments/assets/6d64d41e-4a15-4524-b330-d877aa595f17) |
| Calendar / touch bottom sheet (preserved) | Calendar / touch bottom sheet (preserved) |
