### PR TITLE
fix: link the Techevents brand to the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>techevent-cn · 中国科技活动日历</title>
+    <title>Techevents · 中国科技活动日历</title>
     <meta
       name="description"
       content="中国（及周边）科技活动日历 — VueConf、AdventureX、上海 LUG 聚会等，开发者可浏览、筛选与订阅。"

--- a/scripts/generate-og.mjs
+++ b/scripts/generate-og.mjs
@@ -122,7 +122,7 @@ function dateLabel(e) {
   return `${e.startDate}${end}`
 }
 
-const SITE = 'event.rizumu.me · techevent-cn'
+const SITE = 'event.rizumu.me · Techevents'
 
 /** satori element helper: h('div', style, ...children). */
 function h(type, style, ...children) {

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -10,7 +10,9 @@ const webcalUrl = computed(() => `webcal://${location.host}${calendarUrl}`)
   <header flex="~ wrap items-center gap-3 justify-between" px-5 py-4>
     <div>
       <h1 text-xl tracking-tight font-700>
-        techevent-cn
+        <RouterLink to="/" title="返回首页" class="rounded focus-visible:outline-2 focus-visible:outline-teal-600 focus-visible:outline-offset-4">
+          Techevents
+        </RouterLink>
       </h1>
       <p text-sm op60>
         中国（及周边）科技活动日历

--- a/src/pages/event/[id].vue
+++ b/src/pages/event/[id].vue
@@ -40,7 +40,7 @@ const resolvedLinks = computed(() => (event.value?.links ?? []).map(resolveEvent
 const missingDetails = computed(() => event.value ? missingContributionFields(event.value) : [])
 
 useSeoMeta({
-  title: () => event.value ? `${event.value.name} · techevent-cn` : '活动不存在 · techevent-cn',
+  title: () => event.value ? `${event.value.name} · Techevents` : '活动不存在 · Techevents',
   description: () => event.value?.description ?? '中国（及周边）科技活动日历',
   ogTitle: () => event.value?.name ?? '活动不存在',
   ogDescription: () => event.value?.description ?? '',
@@ -66,7 +66,7 @@ const past = computed(() => event.value ? isPast(event.value.end) : false)
   <div class="detail-page">
     <header class="site-header">
       <RouterLink to="/" title="返回首页">
-        <span class="site-name">techevent-cn</span>
+        <span class="site-name">Techevents</span>
         <span class="site-caption">中国（及周边）科技活动日历</span>
       </RouterLink>
       <button class="icon-btn" title="切换暗色模式" aria-label="切换暗色模式" @click="toggleDark()">

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -5,7 +5,7 @@ import { siteUrl } from '~/config'
 const { filter, filtered, filteredAnyTime, cities, tags, toggle, reset } = useEvents()
 
 useSeoMeta({
-  ogTitle: 'techevent-cn · 中国科技活动日历',
+  ogTitle: 'Techevents · 中国科技活动日历',
   ogDescription: '中国（及周边）科技活动日历 — 开发者可浏览、筛选与订阅。',
   ogType: 'website',
   ogUrl: siteUrl,

--- a/src/utils/eventMarkdown.ts
+++ b/src/utils/eventMarkdown.ts
@@ -18,7 +18,7 @@ export function eventMarkdown(event: NormalizedEvent): string {
   const lines = [
     `# ${escapeText(event.name.replace(/\s*\n\s*/g, ' '))}`,
     '',
-    `来源：${link('techevent-cn 活动详情', eventCanonicalUrl(event.id))}`,
+    `来源：${link('Techevents 活动详情', eventCanonicalUrl(event.id))}`,
     '',
     '> 可通过来源链接查看最新活动信息，或贡献更正与补充。',
     '',

--- a/test/event-markdown.test.ts
+++ b/test/event-markdown.test.ts
@@ -24,7 +24,7 @@ describe('eventMarkdown', () => {
   it('puts the canonical source directly below the title and exports all collected details', () => {
     expect(eventMarkdown(event)).toBe(`# 开发者大会
 
-来源：[techevent\\-cn 活动详情](<${eventCanonicalUrl(event.id)}>)
+来源：[Techevents 活动详情](<${eventCanonicalUrl(event.id)}>)
 
 > 可通过来源链接查看最新活动信息，或贡献更正与补充。
 


### PR DESCRIPTION
The homepage brand is a plain heading with no home navigation. Make it a keyboard-focusable RouterLink to `/` and use “Techevents” consistently in the homepage and detail-page headers, page/OG titles, generated share images, and exported Markdown attribution.

Repository URLs and contributor instructions continue to identify the existing techevent-cn repository.

Validation: `pnpm test --run` (87 tests), `pnpm lint`, `pnpm typecheck`, and `pnpm build` passed. Verified with agent-browser that clicking the detail-page brand returns to `/`, where the Techevents heading is also a home link.

## Visual changes

Captured with Vishot using matching scenarios, viewport, theme, locale, and a fixed date (2026-09-13). Before: `a7219d4`. After: `f96f051`.

| Before | After |
|---|---|
| ![Before: Homepage / keyboard focus on brand](https://github.com/user-attachments/assets/9d21eaa9-388b-49bf-b9bf-315485c0d6dd) | ![After: Homepage / keyboard focus on brand](https://github.com/user-attachments/assets/ababec45-9ff1-4d8f-be81-4af9eb747d22) |
| Homepage / keyboard focus on brand | Homepage / keyboard focus on brand |
| ![Before: Homepage / mobile dark theme](https://github.com/user-attachments/assets/be7038a3-8d61-4433-b4a1-34951a98b0d2) | ![After: Homepage / mobile dark theme](https://github.com/user-attachments/assets/092c929d-a3b7-4c27-8b14-a4cdb29cec55) |
| Homepage / mobile dark theme | Homepage / mobile dark theme |
| ![Before: Event detail / site brand](https://github.com/user-attachments/assets/f7419666-b410-4ef0-9d3e-66b998376d70) | ![After: Event detail / site brand](https://github.com/user-attachments/assets/83a882c7-e015-47d4-a7d9-5e9db4485f9a) |
| Event detail / site brand | Event detail / site brand |
| ![Before: Generated share image / site brand](https://github.com/user-attachments/assets/ee2f0157-9853-4fe0-b7ac-9a84f9489c2a) | ![After: Generated share image / site brand](https://github.com/user-attachments/assets/408081c6-e786-49f1-abc7-61b86bc80705) |
| Generated share image / site brand | Generated share image / site brand |
